### PR TITLE
feat: Show loading indicator while player buffering

### DIFF
--- a/Source/Views/MediaControlsView.swift
+++ b/Source/Views/MediaControlsView.swift
@@ -20,11 +20,17 @@ struct MediaControlsView: View {
                     .brightness(-0.1)
             }
             Spacer()
-            Button(action: togglePlay) {
-                Image(player.status == .paused ? "play" : "pause", bundle: bundle)
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .brightness(-0.1)
+            if player.status == .buffering {
+                ProgressView()
+                    .scaleEffect(1.5)
+                    .progressViewStyle(CircularProgressViewStyle(tint: Color.white))
+            } else {
+                Button(action: togglePlay) {
+                    Image(player.status == .paused ? "play" : "pause", bundle: bundle)
+                        .resizable()
+                        .frame(width: 48, height: 48)
+                        .brightness(-0.1)
+                }
             }
             Spacer()
             Button(action: player.forward) {


### PR DESCRIPTION
- Implemented a loading indicator in the player to display when the playback buffer is empty until it loads data to play.
- This is accomplished by changing the player status to "buffering" when `isPlaybackBufferEmpty` in the AVPlayer becomes true. The status reverts back to its previous state when `isPlaybackLikelyToKeepUp` becomes true.