### PR TITLE
fix: Maximize button failing to switch orientation to landscape in iOS 16

### DIFF
--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -41,7 +41,12 @@ public struct TPStreamPlayerView: View {
             return
         }
         
-        let orientation: UIInterfaceOrientation = isFullscreen ? .landscapeRight : .portrait
-        UIDevice.current.setValue(orientation.rawValue, forKey: "orientation")
+        let orientation: UIInterfaceOrientationMask = isFullscreen ? .landscapeRight : .portrait
+        if #available(iOS 16.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
+        } else {
+            UIDevice.current.setValue(orientation.rawValue, forKey: "orientation")
+        }
     }
 }


### PR DESCRIPTION
- On iOS 16 or later, changing orientation using `UIDevice` is deprecated. Therefore, we have implemented the `requestGeometryUpdate` method for the same.
- For older iOS versions, we continue to use the previous process.
