### PR TITLE
fix: Playback speed options not showing while video playing

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -43,7 +43,7 @@ class TPStreamPlayer: NSObject, ObservableObject {
     }
     
     private func observePlayerCurrentTimeChange() {
-        let interval = CMTime(value: 1, timescale: CMTimeScale(NSEC_PER_SEC))
+        let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
         playerCurrentTimeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: DispatchQueue.main) { [weak self] progressTime in
             guard let self = self else { return }
 


### PR DESCRIPTION
- Currently, the interval for addPeriodicTimeObserver was set to trigger every nanosecond which resulted in the main thread being blocked and preventing the execution of other code.
- This is fixed by reducing the interval to 0.5 seconds.