### PR TITLE
fix: Extract TPStreamsPlayer obserable attributes to separate class

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -2,10 +2,9 @@ import Foundation
 import CoreMedia
 import AVKit
 
-@available(iOS 13.0, *)
-class TPStreamPlayer: NSObject, ObservableObject {
-    @Published var status: PlayerStatus = .paused
-    @Published var currentTime: Float64?
+class TPStreamPlayer: NSObject {
+    var status: PlayerStatus = .paused
+    var currentTime: Float64?
 
     var player: TPAVPlayer!
     var videoDuration: Float64 {
@@ -156,6 +155,31 @@ class TPStreamPlayer: NSObject, ObservableObject {
     
     func changeVideoQuality(_ videoQuality: VideoQuality){
         self.player.changeVideoQuality(to: videoQuality)
+    }
+}
+
+
+@available(iOS 13.0, *)
+class TPStreamPlayerObservable: TPStreamPlayer, ObservableObject {
+    @Published var observedStatus: PlayerStatus
+    @Published var observedCurrentTime: Float64?
+    
+    override var status: PlayerStatus {
+        didSet {
+            observedStatus = status
+        }
+    }
+    
+    override var currentTime: Float64? {
+        didSet {
+            observedCurrentTime = currentTime
+        }
+    }
+    
+    override init(player: TPAVPlayer) {
+        observedStatus = .paused
+        observedCurrentTime = nil
+        super.init(player: player)
     }
 }
 

--- a/Source/Views/MediaControlsView.swift
+++ b/Source/Views/MediaControlsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 struct MediaControlsView: View {
-    @EnvironmentObject var player: TPStreamPlayer
+    @EnvironmentObject var player: TPStreamPlayerObservable
     
     var body: some View {
         HStack() {
@@ -21,13 +21,13 @@ struct MediaControlsView: View {
                     .brightness(-0.1)
             }
             Spacer()
-            if player.status == .buffering {
+            if player.observedStatus == .buffering {
                 ProgressView()
                     .scaleEffect(1.5)
                     .progressViewStyle(CircularProgressViewStyle(tint: Color.white))
             } else {
                 Button(action: togglePlay) {
-                    Image(player.status == .paused ? "play" : "pause", bundle: bundle)
+                    Image(player.observedStatus == .paused ? "play" : "pause", bundle: bundle)
                         .resizable()
                         .frame(width: 48, height: 48)
                         .brightness(-0.1)

--- a/Source/Views/PlayerControlsView.swift
+++ b/Source/Views/PlayerControlsView.swift
@@ -8,13 +8,13 @@ let bundle = Bundle(identifier: "com.tpstreams.iOSPlayerSDK")! // Access bundle 
 
 @available(iOS 14.0, *)
 struct PlayerControlsView: View {
-    @StateObject private var player: TPStreamPlayer
+    @StateObject private var player: TPStreamPlayerObservable
     @State private var showControls = false
     @State private var controlsHideTimer: Timer?
     @Binding private var isFullscreen: Bool
     
     init(player: TPAVPlayer, isFullscreen: Binding<Bool>){
-        _player = StateObject(wrappedValue: TPStreamPlayer(player: player))
+        _player = StateObject(wrappedValue: TPStreamPlayerObservable(player: player))
         _isFullscreen = isFullscreen
     }
         

--- a/Source/Views/PlayerProgressBar.swift
+++ b/Source/Views/PlayerProgressBar.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 struct PlayerProgressBar: View {
-    @EnvironmentObject var player: TPStreamPlayer
+    @EnvironmentObject var player: TPStreamPlayerObservable
     @State private var isDragging = false
     @State private var draggedLocation: Float64?
     
@@ -20,14 +20,14 @@ struct PlayerProgressBar: View {
                 
                 Rectangle()
                     .foregroundColor(Color.red)
-                    .frame(width: CGFloat(calculateWidthForValue(value: player.currentTime ?? 0, geometry: geometry)), height: 2.5)
+                    .frame(width: CGFloat(calculateWidthForValue(value: player.observedCurrentTime ?? 0, geometry: geometry)), height: 2.5)
                 
                 
                 Circle()
                     .fill(Color.red)
                     .frame(width: 12, height: 12)
                     .scaleEffect(isDragging ? 1.8 : 1.0)
-                    .offset(x: isDragging ? draggedLocation! : calculateWidthForValue(value: player.currentTime ?? 0, geometry: geometry))
+                    .offset(x: isDragging ? draggedLocation! : calculateWidthForValue(value: player.observedCurrentTime ?? 0, geometry: geometry))
                     .gesture(DragGesture()
                         .onChanged(handleThumbDrag)
                         .onEnded { value in

--- a/Source/Views/PlayerSettingsButton.swift
+++ b/Source/Views/PlayerSettingsButton.swift
@@ -5,7 +5,7 @@ struct PlayerSettingsButton: View {
     @State private var showOptions = false
     @State private var currentMenu: SettingsMenu = .main
     
-    @EnvironmentObject var player: TPStreamPlayer
+    @EnvironmentObject var player: TPStreamPlayerObservable
     
     var body: some View {
         HStack {

--- a/Source/Views/TimeIndicatorView.swift
+++ b/Source/Views/TimeIndicatorView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 struct TimeIndicatorView: View {
-    @EnvironmentObject var player: TPStreamPlayer
+    @EnvironmentObject var player: TPStreamPlayerObservable
     
     var body: some View {
         HStack {
-            Text(timeStringFromSeconds(player.currentTime ?? 0))
+            Text(timeStringFromSeconds(player.observedCurrentTime ?? 0))
                 .foregroundColor(Color.white)
                 .fontWeight(.bold)
                 .font(.subheadline)


### PR DESCRIPTION
- Currently, Player control methods and observers are present inside `TPStreamsPlayer` which is also an Observable object and the use of observable objects is only available from iOS 14 onwards, also we cannot use observable objects with a UIView.
- So extracted observable attributes to separate class, now we can use the `TPStreamsPlayer` class with UIView and iOS 11.