### PR TITLE
fix: Fix XIB Module Assignment Issue

### DIFF
--- a/Source/Views/UIKit/Xib/PlayerControls.xib
+++ b/Source/Views/UIKit/Xib/PlayerControls.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" id="Pdx-qm-hxi" customClass="PlayerControlsUIView" customModule="TPStreamsSDK" customModuleProvider="target">
+        <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" id="Pdx-qm-hxi" customClass="PlayerControlsUIView" customModule="TPStreamsSDK">
             <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -106,7 +106,7 @@
                         <action selector="toggleFullScreen:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="42m-nt-Uz0"/>
                     </connections>
                 </button>
-                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1u3-pU-CDM" customClass="ProgressBar" customModule="TPStreamsSDK" customModuleProvider="target">
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1u3-pU-CDM" customClass="ProgressBar" customModule="TPStreamsSDK">
                     <rect key="frame" x="0.0" y="358" width="667" height="17"/>
                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>


### PR DESCRIPTION
- Resolved the `this class is not key value coding-compliant for the key` error when using TPStreamPlayerViewController via Swift Package Manager (SPM). The issue was fixed by disabling "Inherit Module From Target" in Interface Builder and explicitly specifying the module name.
- Following the discussion in this thread [link](https://forums.swift.org/t/can-a-swift-package-include-a-table-view/40498/), the necessary adjustments were made.