### PR TITLE
feat: Release Package in cocoapods

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -8,8 +8,12 @@
 import Foundation
 import AVKit
 import Sentry
-import M3U8Parser
 
+#if CocoaPods
+    import M3U8Kit
+#else
+    import M3U8Parser
+#endif
 
 public class TPAVPlayer: AVPlayer {
     private var accessToken: String

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "11.0"
   spec.swift_versions = '5.0'
   spec.source       = { :git => "https://github.com/testpress/iOSPlayerSDK.git", :tag => "release-in-cocoapods" }
-  spec.source_files  = "Source/*.{h,m,swift}"
+  spec.source_files  = "Source/**/*.{swift,plist}"
   spec.exclude_files = "Classes/Exclude"
   spec.dependency 'Sentry', '~> 8.0.0'
   spec.dependency 'Alamofire', '~> 5.0.0'
@@ -18,4 +18,5 @@ Pod::Spec.new do |spec|
     'OTHER_SWIFT_FLAGS[config=Debug]' => '-DCocoaPods',
     'OTHER_SWIFT_FLAGS[config=Release]' => '-DCocoaPods'
 }
+  spec.resources = 'Source/**/*.{xib,storyboard,xcassets,json,png}'
 end

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -8,10 +8,14 @@ Pod::Spec.new do |spec|
   spec.author             = { "hari-testpress" => "hari@testpress.in" }
   spec.ios.deployment_target = "11.0"
   spec.swift_versions = '5.0'
-  spec.source       = { :git => "https://github.com/testpress/iOSPlayerSDK.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/testpress/iOSPlayerSDK.git", :tag => "release-in-cocoapods" }
   spec.source_files  = "Source/*.{h,m,swift}"
   spec.exclude_files = "Classes/Exclude"
   spec.dependency 'Sentry', '~> 8.0.0'
   spec.dependency 'Alamofire', '~> 5.0.0'
-  spec.dependency 'M3U8Kit', '~> 1.0.0'  
+  spec.dependency 'M3U8Kit', '~> 1.0.0'
+  spec.pod_target_xcconfig = {
+    'OTHER_SWIFT_FLAGS[config=Debug]' => '-DCocoaPods',
+    'OTHER_SWIFT_FLAGS[config=Release]' => '-DCocoaPods'
+}
 end

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name         = "TPStreamsSDK"
+  spec.version      = "1.0.0"
+  spec.summary      = "Integrate TPStreams video playback seamlessly into your iOS app with our powerful iOS player SDK."
+  spec.description  = "TPStreamsSDK is a versatile iOS native SDK with support for both DRM (FairPlay) and non-DRM content."
+  spec.homepage     = "https://developer.tpstreams.com/docs/mobile-sdk/ios-native-sdk/getting-started"
+  spec.license      = { :type => "Apache License", :file => "LICENSE" }
+  spec.author             = { "hari-testpress" => "hari@testpress.in" }
+  spec.ios.deployment_target = "11.0"
+  spec.swift_versions = '5.0'
+  spec.source       = { :git => "https://github.com/testpress/iOSPlayerSDK.git", :tag => "#{spec.version}" }
+  spec.source_files  = "Source/*.{h,m,swift}"
+  spec.exclude_files = "Classes/Exclude"
+  spec.dependency 'Sentry', '~> 8.0.0'
+  spec.dependency 'Alamofire', '~> 5.0.0'
+  spec.dependency 'M3U8Kit', '~> 1.0.0'  
+end


### PR DESCRIPTION
- Added podspec file for our package to release it in Cocoapods.
- Added a compiler flag to import M3U8Parser dependency using the name `M3U8Kit` while building the package for Cocoapods to prevent import errors as they have named the package with a different name in Cocoapods.
- Raised an issue in the M3U8Parser repository to resolve this naming inconsistency between different package managers, [issue](https://github.com/M3U8Kit/M3U8Parser/issues/38).