### PR TITLE
fix: Error while using package via cocoapods

### DIFF
--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -11,6 +11,9 @@ import Sentry
 
 #if SPM
     let bundle = Bundle.module
+#elseif CocoaPods
+    let appBundle = Bundle(for: TPStreamsSDK.self)
+    let bundle = Bundle(url: appBundle.url(forResource: "TPStreamsSDK", withExtension: "bundle")!)!
 #else
     let bundle = Bundle(identifier: "com.tpstreams.iOSPlayerSDK")! // Access bundle using identifier when directly including the framework
 #endif

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |spec|
     'OTHER_SWIFT_FLAGS[config=Release]' => '-DCocoaPods'
 }
   spec.resources = 'Source/**/*.{xib,storyboard,xcassets,json,png}'
+  spec.resource_bundles = {
+    'TPStreamsSDK' => 'Source/**/*.{xib,storyboard,xcassets,json,png}',
+ }
 end


### PR DESCRIPTION
- Previously, resources were not properly bundled within the package, causing errors when attempting to use images from the package in the app.
- This commit bundles images and other resources within the package and initializes the bundle using the bundle URL when the package is integrated via CocoaPods.