### PR TITLE
feat: Add support to play AES-Encrypted videos

### DIFF
--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -19,7 +19,7 @@ class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
     func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
         guard let url = loadingRequest.request.url else { return false }
 
-        if isEncryptionKeyUrl(url), let modifiedURL = modifyURLWithAccessToken(url) {
+        if isEncryptionKeyUrl(url), let modifiedURL = appendAccessToken(url) {
             fetchEncryptionKey(from: modifiedURL) { [weak self] data in
                 self?.setEncryptionKeyResponse(for: loadingRequest, data: data)
             }
@@ -32,7 +32,7 @@ class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
         return url.path.contains("key")
     }
 
-    func modifyURLWithAccessToken(_ url: URL) -> URL? {
+    func appendAccessToken(_ url: URL) -> URL? {
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: true){
             let accessTokenQueryItem = URLQueryItem(name: "access_token", value: self.accessToken)
             components.queryItems = (components.queryItems ?? []) + [accessTokenQueryItem]

--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -1,0 +1,78 @@
+//
+//  ResourceLoaderDelegate.swift
+//  TPStreamsSDK
+//
+//  Created by Testpress on 19/10/23.
+//
+
+import Foundation
+import AVFoundation
+
+class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
+    let accessToken: String
+
+    init(accessToken: String) {
+        self.accessToken = accessToken
+        super.init()
+    }
+
+    func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
+        guard let url = loadingRequest.request.url else { return false }
+
+        if isEncryptionKeyUrl(url), let modifiedURL = modifyURLWithAccessToken(url) {
+            fetchEncryptionKey(from: modifiedURL) { [weak self] data in
+                self?.setEncryptionKeyResponse(for: loadingRequest, data: data)
+            }
+            return true
+        }
+        return false
+    }
+
+    func isEncryptionKeyUrl(_ url: URL) -> Bool {
+        return url.path.contains("key")
+    }
+
+    func modifyURLWithAccessToken(_ url: URL) -> URL? {
+        if var components = URLComponents(url: url, resolvingAgainstBaseURL: true){
+            let accessTokenQueryItem = URLQueryItem(name: "access_token", value: self.accessToken)
+            components.queryItems = (components.queryItems ?? []) + [accessTokenQueryItem]
+            return components.url
+        }
+
+        return url
+    }
+
+    func fetchEncryptionKey(from url: URL, completion: @escaping (Data) -> Void) {
+        let dataTask = URLSession.shared.dataTask(with: url) { data, _, _ in
+            if let data = data {
+                completion(data)
+            }
+        }
+        dataTask.resume()
+    }
+
+    func setEncryptionKeyResponse(for loadingRequest: AVAssetResourceLoadingRequest, data: Data) {
+        if let contentInformationRequest = loadingRequest.contentInformationRequest {
+            contentInformationRequest.contentType = getContentType(contentInformationRequest: contentInformationRequest)
+            contentInformationRequest.isByteRangeAccessSupported = true
+            contentInformationRequest.contentLength = Int64(data.count)
+        }
+
+        loadingRequest.dataRequest?.respond(with: data)
+        loadingRequest.finishLoading()
+    }
+
+    func getContentType(contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) -> String {
+        var contentType = AVStreamingKeyDeliveryPersistentContentKeyType
+
+        if #available(iOS 11.2, *) {
+            if let allowedContentType = contentInformationRequest?.allowedContentTypes?.first {
+                if allowedContentType == AVStreamingKeyDeliveryContentKeyType {
+                    contentType = AVStreamingKeyDeliveryContentKeyType
+                }
+            }
+        }
+
+        return contentType
+    }
+}

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -18,6 +18,7 @@ import Sentry
 public class TPAVPlayer: AVPlayer {
     private var accessToken: String
     private var assetID: String
+    private var resourceLoaderDelegate: ResourceLoaderDelegate
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
@@ -31,6 +32,7 @@ public class TPAVPlayer: AVPlayer {
         }
         self.accessToken = accessToken
         self.assetID = assetID
+        self.resourceLoaderDelegate = ResourceLoaderDelegate(accessToken: accessToken)
 
         super.init()
         fetchAsset()
@@ -56,6 +58,7 @@ public class TPAVPlayer: AVPlayer {
         }
         
         let avURLAsset = AVURLAsset(url: url)
+        avURLAsset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
         self.setPlaybackURL(avURLAsset)
         self.setupDRM(avURLAsset)
         self.populateAvailableVideoQualities(url)

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		03CA2D312A2F757D00532549 /* TimeIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D302A2F757D00532549 /* TimeIndicatorView.swift */; };
 		03CA2D372A30A8E500532549 /* PlayerProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D362A30A8E500532549 /* PlayerProgressBar.swift */; };
 		03CC784D2A6BB6E5005E8F7E /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC784C2A6BB6E5005E8F7E /* VideoPlayerView.swift */; };
+		03CC86682AE142FF002F5D28 /* ResourceLoaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC86672AE142FF002F5D28 /* ResourceLoaderDelegate.swift */; };
 		03CE75002A7946A800B84304 /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CE74FF2A7946A800B84304 /* Time.swift */; };
 		03CE75022A7A337B00B84304 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CE75012A7A337B00B84304 /* UIView.swift */; };
 		8E6389BC2A2724D000306FA4 /* TPStreamPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */; };
@@ -137,6 +138,7 @@
 		03CA2D302A2F757D00532549 /* TimeIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicatorView.swift; sourceTree = "<group>"; };
 		03CA2D362A30A8E500532549 /* PlayerProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerProgressBar.swift; sourceTree = "<group>"; };
 		03CC784C2A6BB6E5005E8F7E /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
+		03CC86672AE142FF002F5D28 /* ResourceLoaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceLoaderDelegate.swift; sourceTree = "<group>"; };
 		03CE74FF2A7946A800B84304 /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Time.swift; sourceTree = "<group>"; };
 		03CE75012A7A337B00B84304 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerView.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				03B809092A2DF8A000AB3D03 /* TPStreamPlayer.swift */,
 				8E6389E82A278D1D00306FA4 /* ContentKeyDelegate.swift */,
 				8E6C5CB12A28AB94003EC948 /* ContentKeyManager.swift */,
+				03CC86672AE142FF002F5D28 /* ResourceLoaderDelegate.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -595,6 +598,7 @@
 				0377C40E2A2B1C7300F7E58F /* BaseAPI.swift in Sources */,
 				03CA2D312A2F757D00532549 /* TimeIndicatorView.swift in Sources */,
 				035351A22A2F49E3001E38F3 /* MediaControlsView.swift in Sources */,
+				03CC86682AE142FF002F5D28 /* ResourceLoaderDelegate.swift in Sources */,
 				03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */,
 				8E6389DF2A2751C800306FA4 /* TPAVPlayer.swift in Sources */,
 				03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */,


### PR DESCRIPTION
- Added AES Encryption support: AVPlayer by default requests a decryption key from the key URL specified in the manifest.but that request will fail with an unauthorized error, So we intercept it and attach an 'access_token' query parameter for authorization using the Resource Loader delegate.