### PR TITLE
fix: Player orientation not changed on fullscreen below iOS 16

### DIFF
--- a/Source/Extensions/UIInterfaceOrientationMask.swift
+++ b/Source/Extensions/UIInterfaceOrientationMask.swift
@@ -1,0 +1,23 @@
+//
+//  UIInterfaceOrientationMask.swift
+//  TPStreamsSDK
+//
+//  Created by Testpress on 16/11/23.
+//
+
+import Foundation
+import UIKit
+
+
+extension UIInterfaceOrientationMask {
+    var toUIInterfaceOrientation: UIInterfaceOrientation {
+        switch self {
+        case .portrait:
+            return UIInterfaceOrientation.portrait
+        case .landscape:
+            return UIInterfaceOrientation.landscapeRight
+        default:
+            return UIInterfaceOrientation.unknown
+        }
+    }
+}

--- a/Source/Extensions/UIView.swift
+++ b/Source/Extensions/UIView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIView {
     func getCurrentOrientation() -> UIInterfaceOrientation {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 16.0, *) {
             if let orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation {
                 return orientation
             }

--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -47,7 +47,7 @@ public struct TPStreamPlayerView: View {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
             windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
         } else {
-            UIDevice.current.setValue(orientation.rawValue, forKey: "orientation")
+            UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
         }
     }
 }

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -124,7 +124,7 @@ extension TPStreamPlayerViewController: FullScreenToggleDelegate {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
             windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
         } else {
-            UIDevice.current.setValue(orientation.rawValue, forKey: "orientation")
+            UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
         }
     }
 }

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0377C40E2A2B1C7300F7E58F /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C40D2A2B1C7300F7E58F /* BaseAPI.swift */; };
 		0377C4112A2B1F0700F7E58F /* Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C4102A2B1F0700F7E58F /* Asset.swift */; };
 		0377C4132A2B272C00F7E58F /* TestpressAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C4122A2B272C00F7E58F /* TestpressAPI.swift */; };
+		037F3BBF2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037F3BBE2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift */; };
 		03913C482A850BF9002E7E0C /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03913C472A850BF9002E7E0C /* ProgressBar.swift */; };
 		03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B809092A2DF8A000AB3D03 /* TPStreamPlayer.swift */; };
 		03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8090B2A2DF9A200AB3D03 /* PlayerControlsView.swift */; };
@@ -120,6 +121,7 @@
 		0377C40D2A2B1C7300F7E58F /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
 		0377C4102A2B1F0700F7E58F /* Asset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
 		0377C4122A2B272C00F7E58F /* TestpressAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestpressAPI.swift; sourceTree = "<group>"; };
+		037F3BBE2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInterfaceOrientationMask.swift; sourceTree = "<group>"; };
 		03913C472A850BF9002E7E0C /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		03B809092A2DF8A000AB3D03 /* TPStreamPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayer.swift; sourceTree = "<group>"; };
 		03B8090B2A2DF9A200AB3D03 /* PlayerControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsView.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 			children = (
 				0321F3262A2E0D1800E08AEE /* AVPlayer.swift */,
 				03CE75012A7A337B00B84304 /* UIView.swift */,
+				037F3BBE2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -581,6 +584,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				037F3BBF2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift in Sources */,
 				03B8FDAE2A69752800DAB7AE /* PlayerControlsUIView.swift in Sources */,
 				8E6389E92A278D1D00306FA4 /* ContentKeyDelegate.swift in Sources */,
 				8E6389DD2A27338F00306FA4 /* AVPlayerBridge.swift in Sources */,
@@ -669,6 +673,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
@@ -698,6 +703,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;


### PR DESCRIPTION
- Previously, player orientation did not switch to landscape on fullscreen for iOS versions below 16. Below iOS 16, we set the orientation using UIDevice but incorrectly used `UIInterfaceOrientationMask` instead of the correct `UIInterfaceOrientation` rawValue. As a result, the orientation did not change.
- This commit resolves the issue by introducing a method via an extension to obtain the equivalent UIInterfaceOrientation from UIInterfaceOrientationMask then used to retrieve the correct orientation and set its raw value on UIDevice.