### PR TITLE
fix: Render dragable thumb properly on progress bar

### DIFF
--- a/Source/Views/UIKit/ProgressBar.swift
+++ b/Source/Views/UIKit/ProgressBar.swift
@@ -1,6 +1,8 @@
 import Foundation
 import UIKit
 
+fileprivate let DRAGGABLE_THUMB_SIZE = 12.0
+
 class ProgressBar: UIControl {
     public var player: TPStreamPlayer!{
         didSet {
@@ -8,7 +10,7 @@ class ProgressBar: UIControl {
         }
     }
     private var totalWidth: CGFloat {
-        return frame.width
+        return frame.width - DRAGGABLE_THUMB_SIZE
     }
     private var isDragging = false
     private var draggedLocation: CGFloat = 0
@@ -68,7 +70,7 @@ class ProgressBar: UIControl {
     private func updateDraggedLocation(with event: UIEvent) {
         if let touch = event.touches(for: self)?.first {
             let touchLocation = touch.location(in: self)
-            draggedLocation = touchLocation.x
+            draggedLocation = touchLocation.x, totalWidth
         }
     }
     
@@ -92,7 +94,7 @@ class ProgressBar: UIControl {
     
     override func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
-        drawBar(context, width: rect.width, color: UIColor.gray.withAlphaComponent(0.7).cgColor) // Gray background bar
+        drawBar(context, width: totalWidth, color: UIColor.gray.withAlphaComponent(0.7).cgColor) // Gray background bar
         drawBar(context, width: bufferedWidth, color: UIColor.white.withAlphaComponent(0.6).cgColor) // Buffered progress bar
         drawBar(context, width: watchedWidth, color: UIColor.red.cgColor) // Watched progress bar
         drawDraggableThumb(context)
@@ -100,13 +102,13 @@ class ProgressBar: UIControl {
     
     private func drawBar(_ context: CGContext, width: CGFloat, color: CGColor){
         context.setFillColor(color)
-        context.fill(CGRect(x: 0, y: 5, width: width, height: 3))
+        context.fill(CGRect(x: DRAGGABLE_THUMB_SIZE / 2, y: 5, width: width, height: 3))
     }
     
     private func drawDraggableThumb(_ context: CGContext){
         context.setFillColor(UIColor.red.cgColor)
-        let circleCenterX = isDragging ? draggedLocation : watchedWidth
-        let size = isDragging ? 16.0 : 14.0
-        context.fillEllipse(in: CGRect(x: circleCenterX - 9, y: frame.height / 2 - 9, width: size, height: size))
+        let circleCenterX = (isDragging ? draggedLocation : watchedWidth)
+        let size = isDragging ? DRAGGABLE_THUMB_SIZE + 2 : DRAGGABLE_THUMB_SIZE
+        context.fillEllipse(in: CGRect(x: max(0, circleCenterX), y: 0, width: size, height: size))
     }
 }

--- a/Source/Views/UIKit/Xib/PlayerControls.xib
+++ b/Source/Views/UIKit/Xib/PlayerControls.xib
@@ -103,7 +103,7 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1u3-pU-CDM" customClass="ProgressBar" customModule="TPStreamsSDK">
-                    <rect key="frame" x="12" y="316.5" width="643" height="18"/>
+                    <rect key="frame" x="12" y="316.5" width="645" height="18"/>
                     <color key="backgroundColor" red="0.37098549014514259" green="0.37098549014514259" blue="0.37098549014514259" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
                     <constraints>
@@ -135,7 +135,7 @@
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="bottom" secondItem="ad7-vR-GCz" secondAttribute="bottom" constant="15" id="ZyW-2f-u8I"/>
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="trailing" secondItem="5BF-uG-JOj" secondAttribute="trailing" constant="18" id="e6F-q7-5uK"/>
                 <constraint firstItem="rJo-p9-gc7" firstAttribute="top" secondItem="1u3-pU-CDM" secondAttribute="bottom" constant="6" id="hh3-zD-ilZ"/>
-                <constraint firstItem="w1Z-d2-tRh" firstAttribute="trailing" secondItem="1u3-pU-CDM" secondAttribute="trailing" constant="12" id="l0a-Ew-w1u"/>
+                <constraint firstItem="w1Z-d2-tRh" firstAttribute="trailing" secondItem="1u3-pU-CDM" secondAttribute="trailing" constant="10" id="l0a-Ew-w1u"/>
                 <constraint firstItem="FGD-AH-xjx" firstAttribute="centerY" secondItem="w1Z-d2-tRh" secondAttribute="centerY" id="lov-zD-hDe"/>
                 <constraint firstItem="FGD-AH-xjx" firstAttribute="centerX" secondItem="w1Z-d2-tRh" secondAttribute="centerX" id="oYf-V1-Jlq"/>
                 <constraint firstItem="rWY-7h-2Dd" firstAttribute="centerX" secondItem="w1Z-d2-tRh" secondAttribute="centerX" id="osC-gk-STn"/>


### PR DESCRIPTION
- Previously, the draggable thumb extended beyond the allocated width of the progress bar and became slightly hidden when in the starting or ending position. 
- This commit resolves the issue by reducing the progress bar width and providing sufficient space for the thumb to overflow at the starting or ending position