### PR TITLE
fix: Allow users to pass completion to TPAVPlayer intializer

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -18,11 +18,13 @@ import Sentry
 public class TPAVPlayer: AVPlayer {
     private var accessToken: String
     private var assetID: String
+    public typealias SetupCompletion = (Error?) -> Void
+    private var setupCompletion: SetupCompletion?
     private var resourceLoaderDelegate: ResourceLoaderDelegate
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String) {
+    public init(assetID: String, accessToken: String, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
@@ -32,6 +34,7 @@ public class TPAVPlayer: AVPlayer {
         }
         self.accessToken = accessToken
         self.assetID = assetID
+        self.setupCompletion = completion
         self.resourceLoaderDelegate = ResourceLoaderDelegate(accessToken: accessToken)
 
         super.init()
@@ -44,9 +47,11 @@ public class TPAVPlayer: AVPlayer {
             
             if let asset = asset {
                 self.setup(withAsset: asset)
+                self.setupCompletion?(nil)
             } else if let error = error{
                 SentrySDK.capture(error: error)
                 debugPrint(error.localizedDescription)
+                self.setupCompletion?(error)
             }
         }
     }

--- a/StoryboardExample/ViewController.swift
+++ b/StoryboardExample/ViewController.swift
@@ -22,7 +22,14 @@ class ViewController: UIViewController {
     }
     
     func setupPlayerView(){
-        player = TPAVPlayer(assetID: "8r65J7EY6NP", accessToken: "c4936043-816a-4404-b165-d7336672e7a7")
+        player = TPAVPlayer(assetID: "8r65J7EY6NP", accessToken: "c4936043-816a-4404-b165-d7336672e7a7"){ error in
+            guard error == nil else {
+                print("Setup error: \(error!.localizedDescription)")
+                return
+            }
+
+            print("TPAVPlayer setup successfully")
+        }
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player
         playerViewController?.delegate = self


### PR DESCRIPTION
- Enable users to provide a completion block to the TPAVPlayer initializer. The completion block is invoked after successful setup or in case of failure. 
- This allows for executing custom code upon successful initialization, such as restricting available resolution for switching