### PR TITLE
feat: Display user-friendly error messages on player errors

### DIFF
--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -12,6 +12,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     var contentID: String?
     var assetID: String?
     var accessToken: String?
+    public var onError: ((Error) -> Void)?
 
     enum ProgramError: Error {
         case missingApplicationCertificate
@@ -86,6 +87,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
 
         self.requestCKC(spcData) { ckcData, error in
             if let error = error {
+                self.onError?(error)
                 keyRequest.processContentKeyResponseError(error)
                 return
             }

--- a/Source/TPStreamPlayerError.swift
+++ b/Source/TPStreamPlayerError.swift
@@ -1,0 +1,41 @@
+public enum TPStreamPlayerError: Error {
+    case resourceNotFound
+    case unauthorizedAccess
+    case failedToFetchLicenseKey
+    case noInternetConnection
+    case serverError
+    case networkTimeout
+    case unknownError
+
+    public var code: Int {
+        switch self {
+        case .resourceNotFound: return 5001
+        case .unauthorizedAccess: return 5002
+        case .failedToFetchLicenseKey: return 5003
+        case .noInternetConnection: return 5004
+        case .serverError: return 5005
+        case .networkTimeout: return 5006
+        case .unknownError: return 5100
+        }
+    }
+        
+    public var message: String {
+        switch self {
+        case .resourceNotFound:
+            return "The video is not available. Please try another one."
+        case .unauthorizedAccess:
+            return "Sorry, you don't have permission to access this video. Please check your credentials and try again."
+        case .failedToFetchLicenseKey:
+            return "There was an issue fetching the license key for this video. Please try again later."
+        case .noInternetConnection:
+            return "Oops! It seems like you're not connected to the internet. Please check your connection and try again."
+        case .serverError:
+            return "We're sorry, but there's an issue on our server. Please try again later."
+        case .networkTimeout:
+            return "The request took too long to process due to a slow or unstable network connection. Please try again."
+        case .unknownError:
+            return "Oops! Something went wrong. Please contact support for assistance and provide details about the issue."
+        }
+    }
+}
+

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		031099F62B28B22C0034D370 /* TPStreamPlayerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031099F52B28B22C0034D370 /* TPStreamPlayerError.swift */; };
 		0321F3272A2E0D1800E08AEE /* AVPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0321F3262A2E0D1800E08AEE /* AVPlayer.swift */; };
 		0326BADB2A335911009ABC58 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0326BADA2A335911009ABC58 /* Sentry */; };
 		0326BADE2A348690009ABC58 /* M3U8Parser in Frameworks */ = {isa = PBXBuildFile; productRef = 0326BADD2A348690009ABC58 /* M3U8Parser */; };
@@ -116,6 +117,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		031099F52B28B22C0034D370 /* TPStreamPlayerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerError.swift; sourceTree = "<group>"; };
 		0321F3262A2E0D1800E08AEE /* AVPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVPlayer.swift; sourceTree = "<group>"; };
 		0353519F2A2EDAFA001E38F3 /* PlayerSettingsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSettingsButton.swift; sourceTree = "<group>"; };
 		035351A12A2F49E3001E38F3 /* MediaControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlsView.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 				03B8090D2A2DFC0F00AB3D03 /* Assets.xcassets */,
 				03B8FDA82A695FED00DAB7AE /* TPStreamPlayerViewController.swift */,
 				03BF8C512B173ED10006CBC1 /* TPStreamPlayerConfiguration.swift */,
+				031099F52B28B22C0034D370 /* TPStreamPlayerError.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				03CA2D312A2F757D00532549 /* TimeIndicatorView.swift in Sources */,
 				035351A22A2F49E3001E38F3 /* MediaControlsView.swift in Sources */,
 				03CC86682AE142FF002F5D28 /* ResourceLoaderDelegate.swift in Sources */,
+				031099F62B28B22C0034D370 /* TPStreamPlayerError.swift in Sources */,
 				03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */,
 				8E6389DF2A2751C800306FA4 /* TPAVPlayer.swift in Sources */,
 				03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */,


### PR DESCRIPTION
- Previously, no actions were taken on API or Network failures, leading to app crashes if the user interacted with the player after those failures.
- This issue has been addressed in the commit by displaying a user-friendly error message on the player in case of errors, preventing the user from accessing the player further.