### PR TITLE
refactor: Return if player seek value is `NaN`

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -153,10 +153,13 @@ class TPStreamPlayer: NSObject {
     }
 
     func goTo(seconds: Float64) {
-        // Here we are validation the second value because if there is no network second will be NaN
-        let validatedSecond = seconds.isNaN ? 0.0 : seconds
-        currentTime = NSNumber(value: validatedSecond)
-        let seekTime = CMTime(value: Int64(validatedSecond), timescale: 1)
+        // Here we are validation the second if value is NaN wee will return there is no network second will be NaN
+        guard !seconds.isNaN else {
+                print("Invalid seconds value: NaN")
+                return
+            }
+        currentTime = NSNumber(value: seconds)
+        let seekTime = CMTime(value: Int64(seconds), timescale: 1)
         isSeeking = true
         player?.seek(to: seekTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero){ [weak self] _ in
             guard let self = self else { return }

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -48,7 +48,7 @@ class PlayerControlsUIView: UIView {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == #keyPath(TPStreamPlayer.status) {
             handlePlayerStatusChange()
-        } else if keyPath == #keyPath(TPStreamPlayer.currentTime) {
+        } else if keyPath == #keyPath(TPStreamPlayer.currentTime) && player.isVideoDurationInitialized {
             currentTimelabel.text = timeStringFromSeconds(player.currentTime.doubleValue)
         } else if keyPath == #keyPath(TPStreamPlayer.isVideoDurationInitialized) && player.isVideoDurationInitialized {
             videoDurationLabel.text = timeStringFromSeconds(player.videoDuration)


### PR DESCRIPTION
- The commit 4e1ed48 introduced validation for the seek value, setting it to 0.0 if the value is NaN.
- In this commit, we examine the seek value, and if it is NaN, we exit the process. Additionally, we've implemented logic to update the current time if the video duration is initialized.