### PR TITLE
feat: Use static token for API authorization

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -12,8 +12,7 @@ import AVKit
 struct ContentView: View {
     var body: some View {
         VStack {
-            let player = TPAVPlayer(assetID: "8eaHZjXt6km",
-                                    accessToken: "16b608ba-9979-45a0-94fb-b27c1a86b3c1")
+            let player = TPAVPlayer(assetID: "8eaHZjXt6km")
             TPStreamPlayerView(player: player)
                 .frame(height: 240)
             Spacer()

--- a/Example/ExampleApp.swift
+++ b/Example/ExampleApp.swift
@@ -12,7 +12,7 @@ import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        TPStreamsSDK.initialize(withOrgCode: "6eafqn")
+        TPStreamsSDK.initialize(withOrgCode: "6eafqn", authToken: "98d0f66a38144bdae77f422bb0f15649dc1897f04952cae6fbbcaab8c2b9ab6a")
         return true
     }
 }

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -11,7 +11,6 @@ import Sentry
 class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     var contentID: String?
     var assetID: String?
-    var accessToken: String?
     public var onError: ((Error) -> Void)?
 
     enum ProgramError: Error {
@@ -98,13 +97,11 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     }
 
     func requestCKC(_ spcData: Data, _ completion: @escaping(Data?, Error?) -> Void) {
-        guard let assetID = assetID,
-              let accessToken = accessToken else { return }
-        TPStreamsSDK.provider.API.getDRMLicense(assetID, accessToken, spcData, contentID!, completion)
+        guard let assetID = assetID else { return }
+        TPStreamsSDK.provider.API.getDRMLicense(assetID, spcData, contentID!, completion)
     }
     
-    func setAssetDetails(_ assetID: String, _ accessToken: String) {
+    func setAssetDetails(_ assetID: String) {
         self.assetID = assetID
-        self.accessToken = accessToken
     }
 }

--- a/Source/Network/BaseAPI.swift
+++ b/Source/Network/BaseAPI.swift
@@ -15,11 +15,16 @@ class BaseAPI {
     class var DRM_LICENSE_API: String {
         fatalError("DRM_LICENSE_API must be implemented by subclasses.")
     }
+    class var AUTH_TOKEN_PREFIX: String {
+        fatalError("AUTH_TOKEN_PREFIX must be implemented by subclasses.")
+    }
 
-    static func getAsset(_ assetID: String, _ accessToken: String, completion: @escaping (Asset?, Error?) -> Void) {
-        let url = URL(string: String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID, accessToken))!
+    static func getAsset(_ assetID: String, completion: @escaping (Asset?, Error?) -> Void) {
+        let url = URL(string: String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID))!
+        let headers: HTTPHeaders = [
+            .authorization("\(self.AUTH_TOKEN_PREFIX) \(TPStreamsSDK.authToken!)")]
 
-        AF.request(url).responseData { response in
+        AF.request(url, headers: headers).responseData { response in
             switch response.result {
             case .success(let data):
                 handleResponse(response, data, completion)
@@ -29,8 +34,8 @@ class BaseAPI {
         }
     }
     
-    static func getDRMLicense(_ assetID: String, _ accessToken: String, _ spcData: Data, _ contentID: String, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
-        let url = URL(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID, accessToken))!
+    static func getDRMLicense(_ assetID: String, _ spcData: Data, _ contentID: String, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
+        let url = URL(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID))!
         
         let parameters = [
             "spc": spcData.base64EncodedString(),
@@ -38,7 +43,8 @@ class BaseAPI {
         ] as [String : String]
         
         let headers: HTTPHeaders = [
-            .contentType("application/json")
+            .contentType("application/json"),
+            .authorization("\(self.AUTH_TOKEN_PREFIX) \(TPStreamsSDK.authToken!)")
         ]
         
         AF.request(url, method: .post, parameters: parameters, encoder: JSONParameterEncoder.prettyPrinted, headers: headers).responseData { response in

--- a/Source/Network/StreamsAPI.swift
+++ b/Source/Network/StreamsAPI.swift
@@ -9,11 +9,15 @@ import Foundation
 
 class StreamsAPI: BaseAPI {
     class override var VIDEO_DETAIL_API: String {
-        return "https://app.tpstreams.com/api/v1/%@/assets/%@/?access_token=%@"
+        return "https://app.tpstreams.com/api/v1/%@/assets/%@/"
     }
     
     class override var DRM_LICENSE_API: String {
-        return "https://app.tpstreams.com/api/v1/%@/assets/%@/drm_license/?access_token=%@&drm_type=fairplay"
+        return "https://app.tpstreams.com/api/v1/%@/assets/%@/drm_license/?drm_type=fairplay"
+    }
+    
+    class override var AUTH_TOKEN_PREFIX: String {
+        return "Token"
     }
 
     override class func parseAsset(data: Data) throws -> Asset {

--- a/Source/Network/TestpressAPI.swift
+++ b/Source/Network/TestpressAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class TestpressAPI: BaseAPI {
     class override var VIDEO_DETAIL_API: String { 
-        return "https://%@.testpress.in/api/v2.5/video_info/%@" 
+        return "https://%@.testpress.in/api/v2.5/video_info/%@/" 
     }
 
     class override var DRM_LICENSE_API: String { 

--- a/Source/Network/TestpressAPI.swift
+++ b/Source/Network/TestpressAPI.swift
@@ -9,11 +9,15 @@ import Foundation
 
 class TestpressAPI: BaseAPI {
     class override var VIDEO_DETAIL_API: String { 
-        return "https://%@.testpress.in/api/v2.5/video_info/%@?access_token=%@" 
+        return "https://%@.testpress.in/api/v2.5/video_info/%@" 
     }
 
     class override var DRM_LICENSE_API: String { 
-        return "https://%@.testpress.in/api/v2.5/drm_license_key/%@/?access_token=%@&drm_type=fairplay" 
+        return "https://%@.testpress.in/api/v2.5/drm_license_key/%@/&drm_type=fairplay"
+    }
+    
+    class override var AUTH_TOKEN_PREFIX: String {
+        return "JWT"
     }
 
     override class func parseAsset(data: Data) throws -> Asset {

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -16,7 +16,6 @@ import Sentry
 #endif
 
 public class TPAVPlayer: AVPlayer {
-    private var accessToken: String
     private var assetID: String
     public typealias SetupCompletion = (Error?) -> Void
     private var setupCompletion: SetupCompletion?
@@ -26,25 +25,24 @@ public class TPAVPlayer: AVPlayer {
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String, completion: SetupCompletion? = nil) {
+    public init(assetID: String, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
         
-        if accessToken.isEmpty || assetID.isEmpty {
-            fatalError("AccessToken/AssetID cannot be empty")
+        if assetID.isEmpty {
+            fatalError("AssetID cannot be empty")
         }
-        self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion
-        self.resourceLoaderDelegate = ResourceLoaderDelegate(accessToken: accessToken)
+        self.resourceLoaderDelegate = ResourceLoaderDelegate()
 
         super.init()
         fetchAsset()
     }
     
     private func fetchAsset() {
-        TPStreamsSDK.provider.API.getAsset(assetID, accessToken) { [weak self] asset, error in
+        TPStreamsSDK.provider.API.getAsset(assetID) { [weak self] asset, error in
             guard let self = self else { return }
             
             if let asset = asset {
@@ -80,7 +78,7 @@ public class TPAVPlayer: AVPlayer {
     
     private func setupDRM(_ avURLAsset: AVURLAsset) {
         ContentKeyManager.shared.contentKeySession.addContentKeyRecipient(avURLAsset)
-        ContentKeyManager.shared.contentKeyDelegate.setAssetDetails(assetID, accessToken)
+        ContentKeyManager.shared.contentKeyDelegate.setAssetDetails(assetID)
         ContentKeyManager.shared.contentKeyDelegate.onError = { error in
             self.initializationError = error
             self.onError?(error)

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -21,11 +21,13 @@ import Sentry
 
 public class TPStreamsSDK {
     internal static var orgCode: String?
+    internal static var authToken: String?
     internal static var provider: Provider = .tpstreams
     
-    public static func initialize(for provider: Provider = .tpstreams, withOrgCode orgCode: String) {
+    public static func initialize(for provider: Provider = .tpstreams, withOrgCode orgCode: String, authToken: String) {
         self.orgCode = orgCode
         self.provider = provider
+        self.authToken = authToken
         self.activateAudioSession()
         self.initializeSentry()
     }

--- a/Source/Views/SwiftUI/PlayerControlsView.swift
+++ b/Source/Views/SwiftUI/PlayerControlsView.swift
@@ -60,8 +60,7 @@ struct TPVideoPlayerControls_Previews: PreviewProvider {
     static var previews: some View {
         PlayerControlsView(
             player: TPAVPlayer(
-                assetID: "dummy",
-                accessToken: "dummy"
+                assetID: "dummy"
             ),
             isFullscreen: .constant(true)
         ).background(Color.black)

--- a/StoryboardExample/AppDelegate.swift
+++ b/StoryboardExample/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        TPStreamsSDK.initialize(withOrgCode: "6eafqn")
+        TPStreamsSDK.initialize(withOrgCode: "6eafqn", authToken: "98d0f66a38144bdae77f422bb0f15649dc1897f04952cae6fbbcaab8c2b9ab6a")
         return true
     }
 

--- a/StoryboardExample/ViewController.swift
+++ b/StoryboardExample/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
     }
     
     func setupPlayerView(){
-        player = TPAVPlayer(assetID: "8r65J7EY6NP", accessToken: "c4936043-816a-4404-b165-d7336672e7a7"){ error in
+        player = TPAVPlayer(assetID: "8r65J7EY6NP"){ error in
             guard error == nil else {
                 print("Setup error: \(error!.localizedDescription)")
                 return


### PR DESCRIPTION
-  Implemented support for passing a static authorization key to the SDK initialize method, where Knox auth token is used for TPStreams, and JWT is used for Testpress
- Used the provided token for API authorization.
- Removed the SDK's dependency on access tokens.