### PR TITLE
fix: Capture player errors in sentry

### DIFF
--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -64,7 +64,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
                                                           completionHandler:encryptedSPCMessageCallback)
             
         } catch {
-            SentrySDK.capture(error: error)
+            captureErrorInSentry(error, assetID, accessToken)
             keyRequest.processContentKeyResponseError(error)
         }
     }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -61,6 +61,7 @@ public class TPAVPlayer: AVPlayer {
                 self.onError?(error)
                 self.initializationError = error
                 self.initializationStatus = "error"
+                captureErrorInSentry(error, assetID, accessToken)
                 if self.isNetworkUnavailableError(error){
                     self.retryFetchAssetWhenNetworkIsReady()
                 }

--- a/Source/TPStreamPlayerError.swift
+++ b/Source/TPStreamPlayerError.swift
@@ -1,3 +1,5 @@
+import Sentry
+
 public enum TPStreamPlayerError: Error {
     case resourceNotFound
     case unauthorizedAccess
@@ -39,3 +41,12 @@ public enum TPStreamPlayerError: Error {
     }
 }
 
+extension TPStreamPlayerError: CustomNSError {    
+    public var errorCode: Int {
+        return self.code
+    }
+    
+    public var errorUserInfo: [String : Any] {
+        return [NSDebugDescriptionErrorKey: self.message]
+    }
+}

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -46,8 +46,11 @@ public class TPStreamsSDK {
             options.debug = false
             options.tracesSampleRate = 1.0
             options.enablePreWarmedAppStartTracing = true
-            options.attachScreenshot = true
-            options.attachViewHierarchy = true
+            options.attachScreenshot = false
+            options.attachViewHierarchy = false
+        }
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: "orgCode", key: orgCode!)
         }
     }
 }

--- a/Source/Utils/Sentry.swift
+++ b/Source/Utils/Sentry.swift
@@ -8,12 +8,12 @@
 import Foundation
 import Sentry
 
-func captureErrorInSentry(_ error: Error, assetID: String?, accessToken: String?) {
+func captureErrorInSentry(_ error: Error,_ assetID: String?, _ accessToken: String?) {
     SentrySDK.capture(error: error) { scope in
-        scope.setTag(value: "assetID", key: assetID ?? "")
+        scope.setTag(value: assetID ?? "", key: "assetID")
         
         let additionalInfo = [
-            "accessToken": accessToken ?? ""
+            "accessToken": accessToken
         ]
         scope.setContext(value: additionalInfo, key: "Additional Info")
     }

--- a/Source/Utils/Sentry.swift
+++ b/Source/Utils/Sentry.swift
@@ -1,0 +1,20 @@
+//
+//  Sentry.swift
+//  TPStreamsSDK
+//
+//  Created by Hari on 21/02/24.
+//
+
+import Foundation
+import Sentry
+
+func captureErrorInSentry(_ error: Error, assetID: String?, accessToken: String?) {
+    SentrySDK.capture(error: error) { scope in
+        scope.setTag(value: "assetID", key: assetID ?? "")
+        
+        let additionalInfo = [
+            "accessToken": accessToken ?? ""
+        ]
+        scope.setContext(value: additionalInfo, key: "Additional Info")
+    }
+}

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0326BADE2A348690009ABC58 /* M3U8Parser in Frameworks */ = {isa = PBXBuildFile; productRef = 0326BADD2A348690009ABC58 /* M3U8Parser */; };
 		035351A02A2EDAFA001E38F3 /* PlayerSettingsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0353519F2A2EDAFA001E38F3 /* PlayerSettingsButton.swift */; };
 		035351A22A2F49E3001E38F3 /* MediaControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035351A12A2F49E3001E38F3 /* MediaControlsView.swift */; };
+		0367F6F52B861CFC0000922D /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0367F6F42B861CFC0000922D /* Sentry.swift */; };
 		0377C40E2A2B1C7300F7E58F /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C40D2A2B1C7300F7E58F /* BaseAPI.swift */; };
 		0377C4112A2B1F0700F7E58F /* Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C4102A2B1F0700F7E58F /* Asset.swift */; };
 		0377C4132A2B272C00F7E58F /* TestpressAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377C4122A2B272C00F7E58F /* TestpressAPI.swift */; };
@@ -122,6 +123,7 @@
 		0321F3262A2E0D1800E08AEE /* AVPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVPlayer.swift; sourceTree = "<group>"; };
 		0353519F2A2EDAFA001E38F3 /* PlayerSettingsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSettingsButton.swift; sourceTree = "<group>"; };
 		035351A12A2F49E3001E38F3 /* MediaControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlsView.swift; sourceTree = "<group>"; };
+		0367F6F42B861CFC0000922D /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
 		0377C40D2A2B1C7300F7E58F /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
 		0377C4102A2B1F0700F7E58F /* Asset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
 		0377C4122A2B272C00F7E58F /* TestpressAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestpressAPI.swift; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 			isa = PBXGroup;
 			children = (
 				03CE74FF2A7946A800B84304 /* Time.swift */,
+				0367F6F42B861CFC0000922D /* Sentry.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 				035351A02A2EDAFA001E38F3 /* PlayerSettingsButton.swift in Sources */,
 				03913C482A850BF9002E7E0C /* ProgressBar.swift in Sources */,
 				8E6C5CB52A28BD9A003EC948 /* TPStreamsSDK.swift in Sources */,
+				0367F6F52B861CFC0000922D /* Sentry.swift in Sources */,
 				0377C4132A2B272C00F7E58F /* TestpressAPI.swift in Sources */,
 				0377C4112A2B1F0700F7E58F /* Asset.swift in Sources */,
 				8E6389E22A275AA800306FA4 /* StreamsAPI.swift in Sources */,


### PR DESCRIPTION
- Added support for capturing player errors in Sentry in this commit. Additionally, pass along some information such as orgCode, assetID, and access token of the current playback.
- Disabled attachScreenshot and attachViewHierarchy. Enabling these features was causing issues with the Sentry capture error method.
