### PR TITLE
feat: Add support to play live stream

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -9,7 +9,15 @@ class TPStreamPlayer: NSObject {
     
     var player: TPAVPlayer!
     var videoDuration: Float64 {
-        player.durationInSeconds
+        guard let currentItem = player?.currentItem else {
+            return CMTimeGetSeconds(CMTime.zero)
+        }
+        
+        if let liveStream = player.asset?.liveStream, liveStream.isStreaming {
+            return currentItem.seekableTimeRanges.last?.timeRangeValue.end.seconds ?? CMTimeGetSeconds(CMTime.zero)
+        } else {
+            return player.durationInSeconds
+        }
     }
     var bufferedDuration: Float64 {
         player.bufferedDuration()

--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -13,6 +13,16 @@ struct Asset {
     let contentType: String
     let video: Video?
     let liveStream: LiveStream?
+    
+    var playbackURL: String? {
+        if let video = video {
+            return video.playbackURL
+        } else if let liveStream = liveStream {
+            return liveStream.hlsUrl
+        } else {
+            return nil
+        }
+    }
 }
 
 struct Video{
@@ -27,4 +37,8 @@ struct LiveStream{
     let transcodeRecordedVideo: Bool
     let chatEmbedUrl: String
     let noticeMessage: String?
+    
+    var isStreaming: Bool {
+        return status == "Streaming"
+    }
 }

--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -39,6 +39,6 @@ struct LiveStream{
     let noticeMessage: String?
     
     var isStreaming: Bool {
-        return status == "Streaming"
+        return status == "Streaming" || status == "Running"
     }
 }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -70,8 +70,8 @@ public class TPAVPlayer: AVPlayer {
     }
     
     private func setup() {
-        guard let asset = asset, let urlString = asset.video?.playbackURL, let url = URL(string: urlString) else {
-            debugPrint("Invalid playback URL received from API: \(asset?.video?.playbackURL ?? "nil")")
+        guard let asset = asset, let urlString = asset.playbackURL, let url = URL(string: urlString) else {
+            debugPrint("Invalid playback URL received from API: \(asset?.playbackURL ?? "nil")")
             return
         }
         


### PR DESCRIPTION
- Passed the live stream HLS URL to the player for live stream assets that are currently streaming.
- Modified the video duration fetching logic to correctly handle live streaming durations, as they differ from on-demand video duration.