### PR TITLE
feat: Add Realm Database and OfflineAsset model

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.9.1")),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "8.36.0")),
     .package(url: "https://github.com/M3U8Kit/M3U8Parser", .upToNextMajor(from: "1.1.0")),
-    .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMajor(from: "5.2.2"))
+    .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMajor(from: "5.2.2")),
+    .package(url: "https://github.com/realm/realm-swift", exact: "10.45.0")
   ],
 
   targets: [
@@ -30,6 +31,7 @@ let package = Package(
         "M3U8Parser",
         .product(name: "Sentry", package: "sentry-cocoa"),
         .product(name: "Reachability", package: "Reachability.swift"),
+        .product(name: "RealmSwift", package: "realm-swift")
       ],
       path: "Source",
       resources: [

--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -1,0 +1,31 @@
+//
+//  OfflineAsset.swift
+//  TPStreamsSDK
+//
+//  Created by Prithuvi on 04/10/24.
+//
+
+import Foundation
+
+public struct OfflineAsset: Hashable {
+    public var assetId: String = ""
+    public var createdAt = Date()
+    public var title: String = ""
+    public var downloadedAt = Date()
+    public var status:String = Status.notStarted.rawValue
+    public var percentageCompleted: Double = 0.0
+    public var resolution: String = ""
+    public var duration: Double = 0.0
+    public var bitRate: Double = 0.0
+    public var size: Double = 0.0
+    public var folderTree: String = ""
+}
+
+
+public enum Status: String {
+    case notStarted = "notStarted"
+    case inProgress = "inProgress"
+    case paused = "paused"
+    case finished = "finished"
+    case failed = "failed"
+}

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -1,0 +1,46 @@
+//
+//  OfflineAssetEntity.swift
+//  TPStreamsSDK
+//
+//  Created by Prithuvi on 04/10/24.
+//
+
+import Foundation
+import RealmSwift
+
+class LocalOfflineAsset: Object {
+    @Persisted(primaryKey: true) var assetId: String = ""
+    @Persisted var createdAt = Date()
+    @Persisted var srcURL: String = ""
+    @Persisted var title: String = ""
+    @Persisted var downloadedPath: String = ""
+    @Persisted var downloadedAt = Date()
+    @Persisted var status:String = Status.notStarted.rawValue
+    @Persisted var percentageCompleted: Double = 0.0
+    @Persisted var resolution: String = ""
+    @Persisted var duration: Double = 0.0
+    @Persisted var bitRate: Double = 0.0
+    @Persisted var size: Double = 0.0
+    @Persisted var folderTree: String = ""
+    
+    static var manager = ObjectManager<LocalOfflineAsset>()
+}
+
+extension LocalOfflineAsset {
+    
+    func asOfflineAsset() -> OfflineAsset {
+        return OfflineAsset(
+            assetId: self.assetId,
+            createdAt: self.createdAt,
+            title: self.title,
+            downloadedAt: self.downloadedAt,
+            status: self.status,
+            percentageCompleted: self.percentageCompleted,
+            resolution: self.resolution,
+            duration: self.duration,
+            bitRate: self.bitRate,
+            size: self.size,
+            folderTree: self.folderTree
+        )
+    }
+}

--- a/Source/Database/ObjectManager.swift
+++ b/Source/Database/ObjectManager.swift
@@ -1,0 +1,40 @@
+//
+//  ObjectManager.swift
+//  TPStreamsSDK
+//
+//  Created by Prithuvi on 04/10/24.
+//
+
+import Foundation
+import RealmSwift
+
+public class ObjectManager<T: Object> {
+    let realm = try! Realm()
+    
+    func add(object: T) {
+        try! realm.write {
+            realm.add(object)
+        }
+    }
+    
+    func get(id: Any) -> T? {
+        return realm.object(ofType: T.self, forPrimaryKey: id)
+    }
+    
+    func update(object: T, with attributes: [String: Any]) {
+        try! realm.write {
+            for (key, value) in attributes {
+                object[key] = value
+            }
+        }
+    }
+    
+    func exists(id: Any) -> Bool {
+        let object = realm.object(ofType: T.self, forPrimaryKey: id)
+        return object != nil
+    }
+    
+    func getAll() -> Results<T> {
+        return realm.objects(T.self)
+    }
+}

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AVFoundation
 import Sentry
+import RealmSwift
 
 #if SPM
 let bundle = Bundle.module
@@ -28,6 +29,7 @@ public class TPStreamsSDK {
         self.provider = provider
         self.activateAudioSession()
         self.initializeSentry()
+        self.initializeDatabase()
     }
     
     private static func activateAudioSession() {
@@ -52,6 +54,12 @@ public class TPStreamsSDK {
         SentrySDK.configureScope { scope in
             scope.setTag(value: orgCode!, key: "orgCode")
         }
+    }
+    
+    private static func initializeDatabase() {
+        let identifier = "TPStreamPlayerSDK"
+        let config = Realm.Configuration(inMemoryIdentifier: identifier,schemaVersion: 1)
+        Realm.Configuration.defaultConfiguration = config
     }
 }
 

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'Alamofire', '~> 5.9.0'
   spec.dependency 'M3U8Kit', '~> 1.1.0'
   spec.dependency 'ReachabilitySwift', '~> 5.2.2'
+  spec.dependency 'RealmSwift', '~> 10.45.0'
 
   spec.pod_target_xcconfig = {
     'OTHER_SWIFT_FLAGS[config=Debug]' => '-DCocoaPods',

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -68,6 +68,11 @@
 		8EDE99AF2A2643B000E43EA9 /* TPStreamsSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDE99A42A2643B000E43EA9 /* TPStreamsSDK.framework */; };
 		8EDE99B42A2643B000E43EA9 /* iOSPlayerSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDE99B32A2643B000E43EA9 /* iOSPlayerSDKTests.swift */; };
 		8EDE99B52A2643B000E43EA9 /* iOSPlayerSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EDE99A72A2643B000E43EA9 /* iOSPlayerSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D92E48AD2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48AC2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift */; };
+		D92E48B62CAFBD6F00B1FAC3 /* ObjectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */; };
+		D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */; };
+		D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F02CB0226A00B1FAC3 /* Realm */; };
+		D92E48F32CB0226A00B1FAC3 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +127,16 @@
 			dstSubfolderSpec = 10;
 			files = (
 				8E6389D82A27297500306FA4 /* TPStreamsSDK.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D92E48B42CAFBD2F00B1FAC3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -187,6 +202,9 @@
 		8EDE99AE2A2643B000E43EA9 /* iOSPlayerSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSPlayerSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8EDE99B32A2643B000E43EA9 /* iOSPlayerSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSPlayerSDKTests.swift; sourceTree = "<group>"; };
 		D904B1DD2B3C5BAC00A7E26C /* TPStreamsSDK.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TPStreamsSDK.xctestplan; sourceTree = "<group>"; };
+		D92E48AC2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAssetEntity.swift; sourceTree = "<group>"; };
+		D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectManager.swift; sourceTree = "<group>"; };
+		D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAsset.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,10 +228,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D92E48F32CB0226A00B1FAC3 /* RealmSwift in Frameworks */,
 				0326BADE2A348690009ABC58 /* M3U8Parser in Frameworks */,
 				0394CA312B5E5529006BED3B /* Reachability in Frameworks */,
 				8E6389E52A275B2A00306FA4 /* Alamofire in Frameworks */,
 				0326BADB2A335911009ABC58 /* Sentry in Frameworks */,
+				D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,6 +436,7 @@
 		8EDE99A62A2643B000E43EA9 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				D92E48AA2CAFBCDB00B1FAC3 /* Database */,
 				03D7F4262C22C4D900DF3597 /* Constants */,
 				0397C4852C1C62DA00D701AA /* ViewModels */,
 				03BE54172BF780D1004ED191 /* PrivacyInfo.xcprivacy */,
@@ -442,6 +463,24 @@
 				8EDE99B32A2643B000E43EA9 /* iOSPlayerSDKTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		D92E48AA2CAFBCDB00B1FAC3 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				D92E48AB2CAFBCE900B1FAC3 /* Models */,
+				D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
+		D92E48AB2CAFBCE900B1FAC3 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D92E48AC2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift */,
+				D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -505,6 +544,7 @@
 				8EDE99A12A2643B000E43EA9 /* Frameworks */,
 				8EDE99A22A2643B000E43EA9 /* Resources */,
 				0326BAD82A334EB4009ABC58 /* CopyFiles */,
+				D92E48B42CAFBD2F00B1FAC3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -516,6 +556,8 @@
 				0326BADA2A335911009ABC58 /* Sentry */,
 				0326BADD2A348690009ABC58 /* M3U8Parser */,
 				0394CA302B5E5529006BED3B /* Reachability */,
+				D92E48F02CB0226A00B1FAC3 /* Realm */,
+				D92E48F22CB0226A00B1FAC3 /* RealmSwift */,
 			);
 			productName = iOSPlayerSDK;
 			productReference = 8EDE99A42A2643B000E43EA9 /* TPStreamsSDK.framework */;
@@ -578,6 +620,7 @@
 				0326BAD92A335911009ABC58 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				0326BADC2A348690009ABC58 /* XCRemoteSwiftPackageReference "M3U8Parser" */,
 				0394CA2F2B5E5528006BED3B /* XCRemoteSwiftPackageReference "Reachability" */,
+				D92E48EF2CB0226A00B1FAC3 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = 8EDE99A52A2643B000E43EA9 /* Products */;
 			projectDirPath = "";
@@ -657,6 +700,7 @@
 				037F3BBF2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift in Sources */,
 				03B8FDAE2A69752800DAB7AE /* PlayerControlsUIView.swift in Sources */,
 				0374E3762C1B15C200CE9CF2 /* LiveStream.swift in Sources */,
+				D92E48AD2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift in Sources */,
 				8E6389E92A278D1D00306FA4 /* ContentKeyDelegate.swift in Sources */,
 				0374E3722C1AD2A200CE9CF2 /* TestpressAPIParser.swift in Sources */,
 				8E6389DD2A27338F00306FA4 /* AVPlayerBridge.swift in Sources */,
@@ -680,10 +724,12 @@
 				0377C40E2A2B1C7300F7E58F /* BaseAPI.swift in Sources */,
 				03CA2D312A2F757D00532549 /* TimeIndicatorView.swift in Sources */,
 				035351A22A2F49E3001E38F3 /* MediaControlsView.swift in Sources */,
+				D92E48B62CAFBD6F00B1FAC3 /* ObjectManager.swift in Sources */,
 				03CC86682AE142FF002F5D28 /* ResourceLoaderDelegate.swift in Sources */,
 				031099F62B28B22C0034D370 /* TPStreamPlayerError.swift in Sources */,
 				03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */,
 				8E6389DF2A2751C800306FA4 /* TPAVPlayer.swift in Sources */,
+				D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */,
 				03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */,
 				03D7F4252C21C64D00DF3597 /* LiveIndicatorView.swift in Sources */,
 				0321F3272A2E0D1800E08AEE /* AVPlayer.swift in Sources */,
@@ -996,7 +1042,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1031,7 +1077,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1170,6 +1216,14 @@
 				minimumVersion = 5.9.1;
 			};
 		};
+		D92E48EF2CB0226A00B1FAC3 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift";
+			requirement = {
+				kind = exactVersion;
+				version = 10.45.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1192,6 +1246,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8E6389E32A275B2A00306FA4 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		D92E48F02CB0226A00B1FAC3 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D92E48EF2CB0226A00B1FAC3 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		D92E48F22CB0226A00B1FAC3 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D92E48EF2CB0226A00B1FAC3 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
- In this commit, we added the Realm database via the swift package manager.
- Added `LocalOfflineAsset` model and Initialize Realm database in `TPStreamsSDK`.
- Added Generic ObjectManager class for adding, getting, and updating objects from the database.
- Added Realm database dependencies in `Package.swift` and `TPStreamsSDK.podspec` files.
- Added the `OfflineAsset` model from external use