### PR TITLE
feat: Add Non-DRM video download support

### DIFF
--- a/.github/workflows/ios_test.yml
+++ b/.github/workflows/ios_test.yml
@@ -17,4 +17,4 @@ jobs:
 
       - name: Run Test
         run: |
-          xcodebuild test -project iOSPlayerSDK.xcodeproj -scheme iOSPlayerSDKTests -destination 'platform=iOS Simulator,name=iPhone 12 Pro Max'
+          xcodebuild test -project iOSPlayerSDK.xcodeproj -scheme iOSPlayerSDKTests -destination 'platform=iOS Simulator,name=iPhone 15'

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -16,9 +16,27 @@ struct ContentView: View {
                                     accessToken: "d7ebb4b2-8dee-4dff-bb00-e833195b0756")
             TPStreamPlayerView(player: player)
                 .frame(height: 240)
+            Button(action: {
+                startOfflineDownload()
+            }) {
+                Text("Start Offline Download")
+                    .font(.headline)
+                    .padding()
+                    .foregroundColor(.white)
+                    .background(Color.blue)
+                    .cornerRadius(10)
+            }
+            .padding(.top, 20)
             Spacer()
         }
     }
+    
+    func startOfflineDownload() {
+        print("Starting offline download...")
+        // https://app.tpstreams.com/embed/6eafqn/95hBGFAhQYR/?access_token=7d4e2ffb-3492-4cd4-8e5c-41b7af2f3e7f
+        TPStreamsDownloadManager.shared.startDownload(assetID: "95hBGFAhQYR", accessToken: "7d4e2ffb-3492-4cd4-8e5c-41b7af2f3e7f", resolution: "240p")
+    }
+    
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -32,7 +32,6 @@ struct ContentView: View {
     }
     
     func startOfflineDownload() {
-        print("Starting offline download...")
         // https://app.tpstreams.com/embed/6eafqn/95hBGFAhQYR/?access_token=7d4e2ffb-3492-4cd4-8e5c-41b7af2f3e7f
         TPStreamsDownloadManager.shared.startDownload(assetID: "95hBGFAhQYR", accessToken: "7d4e2ffb-3492-4cd4-8e5c-41b7af2f3e7f", resolution: "240p")
     }

--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -11,6 +11,7 @@ public struct OfflineAsset: Hashable {
     public var assetId: String = ""
     public var createdAt = Date()
     public var title: String = ""
+    public var srcURL: String = ""
     public var downloadedAt = Date()
     public var status:String = Status.notStarted.rawValue
     public var percentageCompleted: Double = 0.0

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -28,6 +28,27 @@ class LocalOfflineAsset: Object {
 
 extension LocalOfflineAsset {
     
+    static func create(
+        assetId: String,
+        srcURL: String,
+        title: String,
+        resolution: String,
+        duration:Double,
+        bitRate: Double,
+        folderTree: String
+    ) -> LocalOfflineAsset {
+        let localOfflineAsset = LocalOfflineAsset()
+        localOfflineAsset.assetId = assetId
+        localOfflineAsset.srcURL = srcURL
+        localOfflineAsset.title = title
+        localOfflineAsset.resolution = resolution
+        localOfflineAsset.duration = duration
+        localOfflineAsset.bitRate = bitRate
+        localOfflineAsset.size = (bitRate * duration)
+        localOfflineAsset.folderTree = folderTree
+        return localOfflineAsset
+    }
+    
     func asOfflineAsset() -> OfflineAsset {
         return OfflineAsset(
             assetId: self.assetId,

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -1,0 +1,115 @@
+//
+//  TPStreamsDownloadManager.swift
+//  TPStreamsSDK
+//
+//  Created by Prithuvi on 07/10/24.
+//
+
+import Foundation
+import AVFoundation
+
+public final class TPStreamsDownloadManager {
+
+    static public let shared = TPStreamsDownloadManager()
+    private var assetDownloadURLSession: AVAssetDownloadURLSession!
+    private var assetDownloadDelegate: AssetDownloadDelegate!
+
+    private init() {
+        let backgroundConfiguration = URLSessionConfiguration.background(withIdentifier: "com.tpstreams.downloadSession")
+        assetDownloadDelegate = AssetDownloadDelegate()
+        assetDownloadURLSession = AVAssetDownloadURLSession(
+            configuration: backgroundConfiguration,
+            assetDownloadDelegate: assetDownloadDelegate,
+            delegateQueue: OperationQueue.main
+        )
+    }
+    
+    public func startDownload(assetID: String, accessToken: String, resolution: String) {
+        TPStreamsSDK.provider.API.getAsset(assetID, accessToken) { [weak self] asset, error in
+            guard let self = self else { return }
+            if let asset = asset {
+                //TODO Create video quality object (dummy for now, can be implemented later)
+                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 519200)
+                startDownload(asset: asset, videoQuality: videoQuality)
+            } else if let error = error{
+                print (error)
+            }
+        }
+    }
+
+    internal func startDownload(asset: Asset, videoQuality: VideoQuality) {
+
+        if LocalOfflineAsset.manager.exists(id: asset.id) {
+            return
+        }
+
+        let avUrlAsset = AVURLAsset(url: URL(string: asset.video!.playbackURL)!)
+
+        guard let task = assetDownloadURLSession.aggregateAssetDownloadTask(
+            with: avUrlAsset,
+            mediaSelections: [avUrlAsset.preferredMediaSelection],
+            assetTitle: asset.title,
+            assetArtworkData: nil,
+            options: [AVAssetDownloadTaskMinimumRequiredMediaBitrateKey: videoQuality.bitrate]
+        ) else { return }
+
+        let localOfflineAsset = LocalOfflineAsset.create(
+            assetId: asset.id,
+            srcURL: asset.video!.playbackURL,
+            title: asset.title,
+            resolution:videoQuality.resolution,
+            duration: 0,
+            bitRate: videoQuality.bitrate,
+            folderTree: ""
+        )
+        LocalOfflineAsset.manager.add(object: localOfflineAsset)
+        assetDownloadDelegate.activeDownloadsMap[task] = localOfflineAsset
+        task.resume()
+    }
+
+}
+
+internal class AssetDownloadDelegate: NSObject, AVAssetDownloadDelegate {
+
+    var activeDownloadsMap = [AVAggregateAssetDownloadTask: LocalOfflineAsset]()
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let assetDownloadTask = task as? AVAggregateAssetDownloadTask else { return }
+        guard let localOfflineAsset = activeDownloadsMap[assetDownloadTask] else { return }
+        updateDownloadCompleteStatus(error, localOfflineAsset)
+        activeDownloadsMap.removeValue(forKey: assetDownloadTask)
+    }
+
+    func urlSession(_ session: URLSession, aggregateAssetDownloadTask: AVAggregateAssetDownloadTask, willDownloadTo location: URL) {
+        guard let localOfflineAsset = activeDownloadsMap[aggregateAssetDownloadTask] else { return }
+        LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["downloadedPath": String(location.relativePath)])
+    }
+
+    func urlSession(_ session: URLSession,
+                    aggregateAssetDownloadTask: AVAggregateAssetDownloadTask,
+                    didLoad timeRange: CMTimeRange,
+                    totalTimeRangesLoaded loadedTimeRanges: [NSValue],
+                    timeRangeExpectedToLoad: CMTimeRange,
+                    for mediaSelection: AVMediaSelection
+    ) {
+        guard let localOfflineAsset = activeDownloadsMap[aggregateAssetDownloadTask] else { return }
+
+        let percentageComplete = calculateDownloadPercentage(loadedTimeRanges, timeRangeExpectedToLoad)
+        LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["status": Status.inProgress.rawValue, "percentageCompleted": percentageComplete])
+    }
+
+    private func updateDownloadCompleteStatus(_ error: Error?,_ localOfflineAsset: LocalOfflineAsset) {
+        let status: Status = (error == nil) ? .finished : .failed
+        let updateValues: [String: Any] = ["status": status.rawValue, "downloadedAt": Date()]
+        LocalOfflineAsset.manager.update(object: localOfflineAsset, with: updateValues)
+    }
+
+    private func calculateDownloadPercentage(_ loadedTimeRanges: [NSValue], _ timeRangeExpectedToLoad: CMTimeRange) -> Double {
+        var percentageComplete = 0.0
+                for value in loadedTimeRanges {
+                    let loadedTimeRange = value.timeRangeValue
+                    percentageComplete += loadedTimeRange.duration.seconds / timeRangeExpectedToLoad.duration.seconds
+                }
+        return percentageComplete * 100
+    }
+}

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -57,8 +57,7 @@ public class TPStreamsSDK {
     }
     
     private static func initializeDatabase() {
-        let identifier = "TPStreamPlayerSDK"
-        let config = Realm.Configuration(inMemoryIdentifier: identifier,schemaVersion: 1)
+        let config = Realm.Configuration(schemaVersion: 1)
         Realm.Configuration.defaultConfiguration = config
     }
 }

--- a/Tests/ObjectManagerTest.swift
+++ b/Tests/ObjectManagerTest.swift
@@ -1,0 +1,33 @@
+//
+//  ObjectManagerTest.swift
+//  iOSPlayerSDKTests
+//
+//  Created by Prithuvi on 07/10/24.
+//
+
+import XCTest
+
+import XCTest
+@testable import TPStreamsSDK
+import RealmSwift
+
+final class ObjectManagerTest: XCTestCase {
+
+    override func setUp() {
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = self.name
+    }
+
+    func testAddAndGetObject() throws {
+        let localOfflineAsset = LocalOfflineAsset()
+        localOfflineAsset.assetId = "test"
+        localOfflineAsset.srcURL = "https://www.test.com.m3u8"
+        // Add object
+        LocalOfflineAsset.manager.add(object: localOfflineAsset)
+        // Get object
+        let retrivedLocalOfflineAsset = LocalOfflineAsset.manager.get(id: "test")
+
+        XCTAssert(retrivedLocalOfflineAsset!.assetId == "test")
+        XCTAssert(retrivedLocalOfflineAsset!.srcURL == "https://www.test.com.m3u8")
+    }
+
+}

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F02CB0226A00B1FAC3 /* Realm */; };
 		D92E48F32CB0226A00B1FAC3 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; };
 		D9CC9A582CB3BF46008037FE /* TPStreamsDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CC9A572CB3BF46008037FE /* TPStreamsDownloadManager.swift */; };
+		D9CC9A5A2CB3CF40008037FE /* ObjectManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CC9A592CB3CF40008037FE /* ObjectManagerTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +208,7 @@
 		D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectManager.swift; sourceTree = "<group>"; };
 		D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAsset.swift; sourceTree = "<group>"; };
 		D9CC9A572CB3BF46008037FE /* TPStreamsDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamsDownloadManager.swift; sourceTree = "<group>"; };
+		D9CC9A592CB3CF40008037FE /* ObjectManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectManagerTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -463,6 +465,7 @@
 			isa = PBXGroup;
 			children = (
 				8EDE99B32A2643B000E43EA9 /* iOSPlayerSDKTests.swift */,
+				D9CC9A592CB3CF40008037FE /* ObjectManagerTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -748,6 +751,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9CC9A5A2CB3CF40008037FE /* ObjectManagerTest.swift in Sources */,
 				8EDE99B42A2643B000E43EA9 /* iOSPlayerSDKTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1114,6 +1118,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tpstreams.iOSPlayerSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1131,6 +1137,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tpstreams.iOSPlayerSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */; };
 		D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F02CB0226A00B1FAC3 /* Realm */; };
 		D92E48F32CB0226A00B1FAC3 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; };
+		D9CC9A582CB3BF46008037FE /* TPStreamsDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CC9A572CB3BF46008037FE /* TPStreamsDownloadManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -205,6 +206,7 @@
 		D92E48AC2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAssetEntity.swift; sourceTree = "<group>"; };
 		D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectManager.swift; sourceTree = "<group>"; };
 		D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAsset.swift; sourceTree = "<group>"; };
+		D9CC9A572CB3BF46008037FE /* TPStreamsDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamsDownloadManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -470,6 +472,7 @@
 			children = (
 				D92E48AB2CAFBCE900B1FAC3 /* Models */,
 				D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */,
+				D9CC9A572CB3BF46008037FE /* TPStreamsDownloadManager.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -727,6 +730,7 @@
 				D92E48B62CAFBD6F00B1FAC3 /* ObjectManager.swift in Sources */,
 				03CC86682AE142FF002F5D28 /* ResourceLoaderDelegate.swift in Sources */,
 				031099F62B28B22C0034D370 /* TPStreamPlayerError.swift in Sources */,
+				D9CC9A582CB3BF46008037FE /* TPStreamsDownloadManager.swift in Sources */,
 				03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */,
 				8E6389DF2A2751C800306FA4 /* TPAVPlayer.swift in Sources */,
 				D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */,


### PR DESCRIPTION
- Added the `TPStreamsDownloadManager` class to provide an API for starting downloads.
- Implemented offline download support for non-DRM videos via the API.
- Added a button in the sample app to initiate downloads.
- Added test cases for adding and retrieving objects.