### PR TITLE
feat: Add support to delete the downloaded video

### DIFF
--- a/Example/AppDownloadManager.swift
+++ b/Example/AppDownloadManager.swift
@@ -42,9 +42,7 @@ class AppDownloadManager: TPStreamsDownloadDelegate, ObservableObject {
     }
     
     func onDelete(assetId: String) {
-        if let index = offlineAssets.firstIndex(where: { $0.assetId == assetId }) {
-            offlineAssets.remove(at: index)
-        }
+        getOfflineAssets()
         print("on Delete", assetId)
     }
 

--- a/Example/AppDownloadManager.swift
+++ b/Example/AppDownloadManager.swift
@@ -40,6 +40,13 @@ class AppDownloadManager: TPStreamsDownloadDelegate, ObservableObject {
     func onResume(offlineAsset: OfflineAsset) {
         print("Download Resume", offlineAsset.assetId)
     }
+    
+    func onDelete(assetId: String) {
+        if let index = offlineAssets.firstIndex(where: { $0.assetId == assetId }) {
+            offlineAssets.remove(at: index)
+        }
+        print("on Delete", assetId)
+    }
 
     @objc func handleOfflineAssetsUpdated() {
         getOfflineAssets()

--- a/Example/Views/OfflineAssetRow.swift
+++ b/Example/Views/OfflineAssetRow.swift
@@ -51,7 +51,7 @@ struct OfflineAssetRow: View {
         case Status.paused.rawValue:
             return [resumeButton(offlineAsset), .cancel()]
         case Status.finished.rawValue:
-            return [playButton(offlineAsset), .cancel()]
+            return [playButton(offlineAsset), deleteButton(offlineAsset), .cancel()]
         default:
             return [.cancel()]
         }
@@ -72,6 +72,12 @@ struct OfflineAssetRow: View {
     private func playButton(_ offlineAsset: OfflineAsset) -> ActionSheet.Button {
         return .default(Text("Play")) {
             showPlayerView = true
+        }
+    }
+    
+    private func deleteButton(_ offlineAsset: OfflineAsset) -> ActionSheet.Button {
+        return .default(Text("Delete")) {
+            TPStreamsDownloadManager.shared.deleteDownload(offlineAsset.assetId)
         }
     }
 }

--- a/Source/Database/ObjectManager.swift
+++ b/Source/Database/ObjectManager.swift
@@ -34,6 +34,13 @@ public class ObjectManager<T: Object> {
         return object != nil
     }
     
+    func delete(id: Any) {
+         try! realm.write {
+             guard let deleteObject = get(id: id) else { return }
+             realm.delete(deleteObject)
+         }
+     }
+    
     func getAll() -> Results<T> {
         return realm.objects(T.self)
     }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -105,6 +105,20 @@ public final class TPStreamsDownloadManager {
         }
     }
     
+    public func deleteDownload(_ offlineAssetId: String) {
+        guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: offlineAssetId),
+              localOfflineAsset.status == Status.finished.rawValue,
+              localOfflineAsset.downloadedFileURL != nil else { return }
+        let localOfflineAssetId = localOfflineAsset.assetId
+        do {
+            try FileManager.default.removeItem(at: localOfflineAsset.downloadedFileURL!)
+            LocalOfflineAsset.manager.delete(id: localOfflineAssetId)
+            tpStreamsDownloadDelegate?.onDelete(assetId: localOfflineAssetId)
+        } catch {
+            print("An error occured trying to delete the contents on disk for \(localOfflineAssetId): \(error)")
+        }
+    }
+    
     public func getAllOfflineAssets() -> [OfflineAsset]{
         return Array(LocalOfflineAsset.manager.getAll().map({ localOfflineAsset in
             localOfflineAsset.asOfflineAsset()
@@ -168,6 +182,7 @@ public protocol TPStreamsDownloadDelegate {
     func onStart(offlineAsset: OfflineAsset)
     func onPause(offlineAsset: OfflineAsset)
     func onResume(offlineAsset: OfflineAsset)
+    func onDelete(assetId: String)
     func onProgressChange(assetId: String, percentage: Double)
     func onStateChange(status: Status, offlineAsset: OfflineAsset)
 }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -35,7 +35,7 @@ public final class TPStreamsDownloadManager {
             guard let self = self else { return }
             if let asset = asset {
                 //TODO Create video quality object (dummy for now, can be implemented later)
-                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 519200)
+                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 4611200)
                 startDownload(asset: asset, videoQuality: videoQuality)
             } else if let error = error{
                 print (error)
@@ -110,10 +110,11 @@ public final class TPStreamsDownloadManager {
               localOfflineAsset.status == Status.finished.rawValue,
               localOfflineAsset.downloadedFileURL != nil else { return }
         let localOfflineAssetId = localOfflineAsset.assetId
+        let downloadedFileURL = localOfflineAsset.downloadedFileURL
         do {
-            try FileManager.default.removeItem(at: localOfflineAsset.downloadedFileURL!)
             LocalOfflineAsset.manager.delete(id: localOfflineAssetId)
             tpStreamsDownloadDelegate?.onDelete(assetId: localOfflineAssetId)
+            try FileManager.default.removeItem(at: downloadedFileURL!)
         } catch {
             print("An error occured trying to delete the contents on disk for \(localOfflineAssetId): \(error)")
         }


### PR DESCRIPTION
- In this commit, we added a delete option for the download videos
- Added `deleteDownload(offlineAssetId)` method in `TPStreamsDownloadManager` this method can be used to delete the downloaded video

