### PR TITLE
fix: Remove Partially Deleted Video

### DIFF
--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -29,4 +29,5 @@ public enum Status: String {
     case paused = "paused"
     case finished = "finished"
     case failed = "failed"
+    case deleted = "deleted"
 }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -35,7 +35,7 @@ public final class TPStreamsDownloadManager {
             guard let self = self else { return }
             if let asset = asset {
                 //TODO Create video quality object (dummy for now, can be implemented later)
-                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 100)
+                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 4611200)
                 startDownload(asset: asset, videoQuality: videoQuality)
             } else if let error = error{
                 print (error)
@@ -132,13 +132,11 @@ public final class TPStreamsDownloadManager {
         LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["status": Status.deleted.rawValue])
         tpStreamsDownloadDelegate?.onDelete(assetId: localOfflineAsset.assetId)
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
-            self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
-                if success {
-                    LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
-                } else {
-                    print("An error occurred trying to delete the contents on disk for \(localOfflineAsset.assetId): \(String(describing: error))")
-                }
+        self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
+            if success {
+                LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
+            } else {
+                print("An error occurred trying to delete the contents on disk for \(localOfflineAsset.assetId): \(String(describing: error))")
             }
         }
     }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -105,7 +105,7 @@ public final class TPStreamsDownloadManager {
         }
     }
     
-    internal func deletePartiallyDeletedVideos() {
+    internal func removePartiallyDeletedVideos() {
         LocalOfflineAsset.manager.getAll().filter { localOfflineAsset in
             localOfflineAsset.status == Status.deleted.rawValue
         }.forEach { localOfflineAsset in

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -30,6 +30,7 @@ public class TPStreamsSDK {
         self.activateAudioSession()
         self.initializeSentry()
         self.initializeDatabase()
+        self.deletePartiallyDeletedVideos()
     }
     
     private static func activateAudioSession() {
@@ -59,6 +60,10 @@ public class TPStreamsSDK {
     private static func initializeDatabase() {
         let config = Realm.Configuration(schemaVersion: 1)
         Realm.Configuration.defaultConfiguration = config
+    }
+    
+    private static func deletePartiallyDeletedVideos() {
+        TPStreamsDownloadManager.shared.deletePartiallyDeletedVideos()
     }
 }
 

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -30,7 +30,7 @@ public class TPStreamsSDK {
         self.activateAudioSession()
         self.initializeSentry()
         self.initializeDatabase()
-        self.deletePartiallyDeletedVideos()
+        self.removePartiallyDeletedVideos()
     }
     
     private static func activateAudioSession() {
@@ -62,8 +62,8 @@ public class TPStreamsSDK {
         Realm.Configuration.defaultConfiguration = config
     }
     
-    private static func deletePartiallyDeletedVideos() {
-        TPStreamsDownloadManager.shared.deletePartiallyDeletedVideos()
+    private static func removePartiallyDeletedVideos() {
+        TPStreamsDownloadManager.shared.removePartiallyDeletedVideos()
     }
 }
 


### PR DESCRIPTION
- Added a deleted status to the `Status` enum for identifying marked assets.
- Implemented `removePartiallyDeletedVideos()` in `TPStreamsDownloadManager` to delete assets with the deleted status and remove corresponding files from the filesystem.
- Modified `deleteDownload()` to update asset status to deleted instead of immediate removal for better tracking.
- Updated `getAllOfflineAssets()` to exclude assets with a deleted status, returning only active assets.
- Integrated cleanup logic into the SDK initialization process to handle deleted assets at startup.