### PR TITLE
feat: Add JWT Authorization Support for API Requests

### DIFF
--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -43,7 +43,14 @@ class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
     }
     
     func fetchEncryptionKey(from url: URL, completion: @escaping (Data) -> Void) {
-        let dataTask = URLSession.shared.dataTask(with: url) { data, _, _ in
+        var request = URLRequest(url: url)
+        
+        // Add Authorization header if authToken is available and non-empty
+        if let authToken = TPStreamsSDK.authToken, !authToken.isEmpty {
+            request.addValue("JWT \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+        
+        let dataTask = URLSession.shared.dataTask(with: request) { data, _, _ in
             if let data = data {
                 completion(data)
             }

--- a/Source/Network/TestpressAPI.swift
+++ b/Source/Network/TestpressAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class TestpressAPI: BaseAPI {
     class override var VIDEO_DETAIL_API: String { 
-        return "https://%@.testpress.in/api/v2.5/video_info/%@?access_token=%@&v=2"
+        return "https://%@.testpress.in/api/v2.5/video_info/%@/?access_token=%@&v=2"
     }
     
     class override var DRM_LICENSE_API: String { 

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -35,8 +35,8 @@ public class TPAVPlayer: AVPlayer {
             fatalError("You must call TPStreamsSDK.initialize")
         }
         
-        if accessToken.isEmpty || assetID.isEmpty {
-            fatalError("AccessToken/AssetID cannot be empty")
+        if assetID.isEmpty {
+            fatalError("AssetID cannot be empty")
         }
         self.accessToken = accessToken
         self.assetID = assetID

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -23,10 +23,12 @@ let bundle = Bundle(identifier: "com.tpstreams.iOSPlayerSDK")! // Access bundle 
 public class TPStreamsSDK {
     internal static var orgCode: String?
     internal static var provider: Provider = .tpstreams
+    internal static var authToken: String?
     
-    public static func initialize(for provider: Provider = .tpstreams, withOrgCode orgCode: String) {
+    public static func initialize(for provider: Provider = .tpstreams, withOrgCode orgCode: String, usingAuthToken authToken: String? = nil) {
         self.orgCode = orgCode
         self.provider = provider
+        self.authToken = authToken
         self.activateAudioSession()
         self.initializeSentry()
         self.initializeDatabase()


### PR DESCRIPTION
- Implemented support for including a JWT authorization token in API requests.
- Updated the `initialize` method to accept an optional `authToken`.
- Added an authorization header to all request headers based on the availability of the `authToken`.
- Updated the API endpoint URL to include a trailing slash after the video ID, ensuring correct server interpretation and avoiding 401 Unauthorized responses.

