### PR TITLE
enhancement: Add cancel download functionality for Offline download

### DIFF
--- a/Example/AppDownloadManager.swift
+++ b/Example/AppDownloadManager.swift
@@ -41,6 +41,11 @@ class AppDownloadManager: TPStreamsDownloadDelegate, ObservableObject {
         print("Download Resume", offlineAsset.assetId)
     }
     
+    func onCanceled(assetId: String) {
+        getOfflineAssets()
+        print("Download Canceled", assetId)
+    }
+    
     func onDelete(assetId: String) {
         getOfflineAssets()
         print("on Delete", assetId)

--- a/Example/Views/OfflineAssetRow.swift
+++ b/Example/Views/OfflineAssetRow.swift
@@ -47,9 +47,9 @@ struct OfflineAssetRow: View {
     func getButtons(_ offlineAsset: OfflineAsset) -> [ActionSheet.Button] {
         switch (offlineAsset.status) {
         case Status.inProgress.rawValue:
-            return [pauseButton(offlineAsset), .cancel()]
+            return [pauseButton(offlineAsset), cancelButton(offlineAsset), .cancel()]
         case Status.paused.rawValue:
-            return [resumeButton(offlineAsset), .cancel()]
+            return [resumeButton(offlineAsset), cancelButton(offlineAsset), .cancel()]
         case Status.finished.rawValue:
             return [playButton(offlineAsset), deleteButton(offlineAsset), .cancel()]
         default:
@@ -66,6 +66,12 @@ struct OfflineAssetRow: View {
     private func resumeButton(_ offlineAsset: OfflineAsset) -> ActionSheet.Button {
         return .default(Text("Resume")) {
             TPStreamsDownloadManager.shared.resumeDownload(offlineAsset.assetId)
+        }
+    }
+    
+    private func cancelButton(_ offlineAsset: OfflineAsset) -> ActionSheet.Button {
+        return .default(Text("Cancel")) {
+            TPStreamsDownloadManager.shared.cancelDownload(offlineAsset.assetId)
         }
     }
     

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -115,7 +115,6 @@ public final class TPStreamsDownloadManager {
             task.cancel()
             self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
                 if success {
-                    print("Success")
                     LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
                 } else {
                     print("An error occurred trying to delete the contents on disk for \(localOfflineAsset.assetId): \(String(describing: error))")

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -105,6 +105,25 @@ public final class TPStreamsDownloadManager {
         }
     }
     
+    public func cancelDownload(_ assetId: String) {
+        guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: assetId) else {
+            print("Asset with ID \(assetId) does not exist.")
+            return
+        }
+        
+        if let task = assetDownloadDelegate.activeDownloadsMap.first(where: { $0.value == localOfflineAsset })?.key {
+            task.cancel()
+            self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
+                if success {
+                    print("Success")
+                    LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
+                } else {
+                    print("An error occurred trying to delete the contents on disk for \(localOfflineAsset.assetId): \(String(describing: error))")
+                }
+            }
+        }
+    }
+    
     internal func removePartiallyDeletedVideos() {
         LocalOfflineAsset.manager.getAll().filter { localOfflineAsset in
             localOfflineAsset.status == Status.deleted.rawValue
@@ -200,11 +219,24 @@ internal class AssetDownloadDelegate: NSObject, AVAssetDownloadDelegate {
     }
 
     private func updateDownloadCompleteStatus(_ error: Error?,_ localOfflineAsset: LocalOfflineAsset) {
-        let status: Status = (error == nil) ? .finished : .failed
+        let status: Status = {
+            switch error {
+            case nil:
+                return .finished
+            case let nsError as NSError where nsError.code == NSURLErrorCancelled:
+                return .deleted
+            default:
+                return .failed
+            }
+        }()
         let updateValues: [String: Any] = ["status": status.rawValue, "downloadedAt": Date()]
         LocalOfflineAsset.manager.update(object: localOfflineAsset, with: updateValues)
-        tpStreamsDownloadDelegate?.onComplete(offlineAsset: localOfflineAsset.asOfflineAsset())
-        tpStreamsDownloadDelegate?.onStateChange(status: status, offlineAsset: localOfflineAsset.asOfflineAsset())
+        if status == Status.deleted {
+            tpStreamsDownloadDelegate?.onCanceled(assetId: localOfflineAsset.assetId)
+        } else {
+            tpStreamsDownloadDelegate?.onComplete(offlineAsset: localOfflineAsset.asOfflineAsset())
+            tpStreamsDownloadDelegate?.onStateChange(status: status, offlineAsset: localOfflineAsset.asOfflineAsset())
+        }
     }
 
     private func calculateDownloadPercentage(_ loadedTimeRanges: [NSValue], _ timeRangeExpectedToLoad: CMTimeRange) -> Double {
@@ -222,6 +254,7 @@ public protocol TPStreamsDownloadDelegate {
     func onStart(offlineAsset: OfflineAsset)
     func onPause(offlineAsset: OfflineAsset)
     func onResume(offlineAsset: OfflineAsset)
+    func onCanceled(assetId: String)
     func onDelete(assetId: String)
     func onProgressChange(assetId: String, percentage: Double)
     func onStateChange(status: Status, offlineAsset: OfflineAsset)


### PR DESCRIPTION
- Added `cancelDownload(assetId:)` method in `TPStreamsDownloadManager`.
- Introduced `onCanceled(assetId:)` method in `TPStreamsDownloadDelegate`.
- Improves user experience by enabling download cancellation and cleaning up partially downloaded files.