### PR TITLE
feat: Add download button in player view

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -41,6 +41,10 @@ class TPStreamPlayer: NSObject {
         return self.player.availableVideoQualities.first( where: {$0.bitrate == self.player.currentItem?.preferredPeakBitRate })
     }
     
+    var asset: Asset? {
+        return self.player.asset
+    }
+    
     init(player: TPAVPlayer){
         self.player = player
         super.init()

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -29,7 +29,7 @@ struct PlayerSettingsButton: View {
             return ActionSheet(
                 title: Text("Settings"),
                 message: nil,
-                buttons: [playbackSpeedButton(), videoQualityButton(), .cancel()]
+                buttons: [playbackSpeedButton(), videoQualityButton(), downloadQualityButton(), .cancel()]
             )
         case .playbackSpeed:
             return ActionSheet(
@@ -42,6 +42,12 @@ struct PlayerSettingsButton: View {
                 title: Text("Video Quality"),
                 message: nil,
                 buttons: videoQualityOptions() + [.cancel()]
+            )
+        case .downloadQuality:
+            return ActionSheet(
+                title: Text("Download Quality"),
+                message: nil,
+                buttons: downloadQualityOptions() + [.cancel()]
             )
         }
     }
@@ -64,6 +70,15 @@ struct PlayerSettingsButton: View {
         }
     }
     
+    private func downloadQualityButton() -> ActionSheet.Button {
+        return .default(Text("Download")) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.showOptions = true
+                self.currentMenu = .downloadQuality
+            }
+        }
+    }
+    
     private func playbackSpeedOptions() -> [ActionSheet.Button] {
         let playbackSpeeds = PlaybackSpeed.allCases
         return playbackSpeeds.map { speed in
@@ -80,6 +95,17 @@ struct PlayerSettingsButton: View {
                 }
         }
     }
+    
+    private func downloadQualityOptions() -> [ActionSheet.Button] {
+        var availableVideoQualities = player.availableVideoQualities
+        // Remove Auto Quality from the Array
+        availableVideoQualities.remove(at: 0)
+        return availableVideoQualities.map { downloadQuality in
+                .default(Text(downloadQuality.resolution)) {
+                    TPStreamsDownloadManager.shared.startDownload(asset: player.asset!, videoQuality: downloadQuality)
+                }
+        }
+    }
 }
 
-enum SettingsMenu { case main, playbackSpeed, videoQuality }
+enum SettingsMenu { case main, playbackSpeed, videoQuality, downloadQuality }

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -152,6 +152,7 @@ class PlayerControlsUIView: UIView {
         optionsMenu.addAction(UIAlertAction(title: "Playback Speed", style: .default) { _ in self.showPlaybackSpeedMenu()})
         optionsMenu.addAction(UIAlertAction(title: "Video Quality", style: .default, handler: { action in self.showVideoQualityMenu()}))
         optionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        optionsMenu.addAction(UIAlertAction(title: "Download", style: .default, handler: { action in self.showDownloadQualityMenu()}))
         parentViewController?.present(optionsMenu, animated: true, completion: nil)
     }
     
@@ -163,6 +164,11 @@ class PlayerControlsUIView: UIView {
     func showVideoQualityMenu(){
         let videoQualityMenu = createVideoQualityMenu()
         parentViewController?.present(videoQualityMenu, animated: true, completion: nil)
+    }
+    
+    func showDownloadQualityMenu(){
+        let downloadQualityMenu = createDownloadQualityMenu()
+        parentViewController?.present(downloadQualityMenu, animated: true, completion: nil)
     }
     
     func createPlaybackSpeedMenu() -> UIAlertController {
@@ -181,6 +187,19 @@ class PlayerControlsUIView: UIView {
         let qualityMenu = UIAlertController(title: "Available resolutions", message: nil, preferredStyle: ACTION_SHEET_PREFERRED_STYLE)
         for quality in self.player.availableVideoQualities {
             let action = createActionForVideoQuality(quality)
+            qualityMenu.addAction(action)
+        }
+        qualityMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        return qualityMenu
+    }
+    
+    func createDownloadQualityMenu() -> UIAlertController {
+        let qualityMenu = UIAlertController(title: "Available resolutions", message: nil, preferredStyle: ACTION_SHEET_PREFERRED_STYLE)
+        var availableVideoQualities = player.availableVideoQualities
+        // Remove Auto Quality from the Array
+        availableVideoQualities.remove(at: 0)
+        for quality in availableVideoQualities {
+            let action = createActionForDownload(quality)
             qualityMenu.addAction(action)
         }
         qualityMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
@@ -207,6 +226,14 @@ class PlayerControlsUIView: UIView {
             action.setValue(UIImage(named: "checkmark", in: bundle, compatibleWith: nil), forKey: "image")
         }
         
+        return action
+    }
+    
+    func createActionForDownload(_ quality: VideoQuality) -> UIAlertAction {
+        let action = UIAlertAction(title: quality.resolution, style: .default, handler: { (_) in
+            TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, videoQuality: quality)
+        })
+
         return action
     }
     


### PR DESCRIPTION
- Introduces a download option in the player view, accessible via the settings button.
- The download option is enabled by default in both Storyboard and SwiftUI.