### PR TITLE
enhancement: Add download option to player configuration

### DIFF
--- a/Example/Views/PlayerView.swift
+++ b/Example/Views/PlayerView.swift
@@ -37,6 +37,7 @@ struct PlayerView: View {
                     .setPreferredRewindDuration(5)
                     .setprogressBarThumbColor(.systemBlue)
                     .setwatchedProgressTrackColor(.systemBlue)
+                    .showDownloadOption()
                     .build()
                 TPStreamPlayerView(player: player, playerViewConfig: playerViewConfig)
                     .frame(height: 240)

--- a/Source/TPStreamPlayerConfiguration.swift
+++ b/Source/TPStreamPlayerConfiguration.swift
@@ -13,6 +13,7 @@ public struct TPStreamPlayerConfiguration {
     public var preferredRewindDuration: TimeInterval = 10.0
     public var watchedProgressTrackColor: UIColor = .red
     public var progressBarThumbColor: UIColor = .red
+    public var showDownloadOption: Bool = false
 }
 
 
@@ -40,6 +41,11 @@ public class TPStreamPlayerConfigurationBuilder {
     
     public func setprogressBarThumbColor(_ color: UIColor) -> Self {
         configuration.progressBarThumbColor = color
+        return self
+    }
+    
+    public func showDownloadOption() -> Self {
+        configuration.showDownloadOption = true
         return self
     }
     

--- a/Source/Views/SwiftUI/PlayerControlsView.swift
+++ b/Source/Views/SwiftUI/PlayerControlsView.swift
@@ -17,7 +17,7 @@ struct PlayerControlsView: View {
     var body: some View {
         VStack{
             if showControls {
-                PlayerSettingsButton()
+                PlayerSettingsButton(playerConfig: playerViewConfig)
                 Spacer()
                 MediaControlsView(playerViewConfig: playerViewConfig)
                 Spacer()

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -6,6 +6,11 @@ struct PlayerSettingsButton: View {
     @State private var currentMenu: SettingsMenu = .main
     
     @EnvironmentObject var player: TPStreamPlayerObservable
+    private var playerConfig: TPStreamPlayerConfiguration
+    
+    init(playerConfig: TPStreamPlayerConfiguration){
+        self.playerConfig = playerConfig
+    }
     
     var body: some View {
         HStack {
@@ -29,7 +34,7 @@ struct PlayerSettingsButton: View {
             return ActionSheet(
                 title: Text("Settings"),
                 message: nil,
-                buttons: [playbackSpeedButton(), videoQualityButton(), downloadQualityButton(), .cancel()]
+                buttons: getMainActionSheetButtons()
             )
         case .playbackSpeed:
             return ActionSheet(
@@ -50,6 +55,18 @@ struct PlayerSettingsButton: View {
                 buttons: downloadQualityOptions() + [.cancel()]
             )
         }
+    }
+    
+    private func getMainActionSheetButtons() -> [ActionSheet.Button] {
+        var actionButtons: [ActionSheet.Button] = [playbackSpeedButton(), videoQualityButton()]
+        
+        if playerConfig.showDownloadOption {
+            actionButtons.append(downloadQualityButton())
+        }
+        
+        actionButtons.append(.cancel())
+        
+        return actionButtons
     }
     
     private func playbackSpeedButton() -> ActionSheet.Button {

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -152,7 +152,9 @@ class PlayerControlsUIView: UIView {
         optionsMenu.addAction(UIAlertAction(title: "Playback Speed", style: .default) { _ in self.showPlaybackSpeedMenu()})
         optionsMenu.addAction(UIAlertAction(title: "Video Quality", style: .default, handler: { action in self.showVideoQualityMenu()}))
         optionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        optionsMenu.addAction(UIAlertAction(title: "Download", style: .default, handler: { action in self.showDownloadQualityMenu()}))
+        if playerConfig.showDownloadOption {
+            optionsMenu.addAction(UIAlertAction(title: "Download", style: .default, handler: { action in self.showDownloadQualityMenu()}))
+        }
         parentViewController?.present(optionsMenu, animated: true, completion: nil)
     }
     

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -54,6 +54,7 @@ class PlayerViewController: UIViewController {
             .setPreferredRewindDuration(5)
             .setprogressBarThumbColor(.systemBlue)
             .setwatchedProgressTrackColor(.systemBlue)
+            .showDownloadOption()
             .build()
         
         playerViewController?.config = config


### PR DESCRIPTION
- Implemented the ability to show or hide the download option in the player settings based on configuration.
- Added `.showDownloadOption()` to `TPStreamPlayerConfigurationBuilder` to enable or disable the download button in both `SwiftUI` and `UIKit` player controls.
- Updated `PlayerSettingsButton` and `PlayerControlsUIView` to conditionally display the download quality option when configured.
- Integrated the download option feature in both `Storyboard` and `SwiftUI` implementations.