### PR TITLE
enhancement: Differentiate Offline and Online Player Settings

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -27,6 +27,7 @@ public class TPAVPlayer: AVPlayer {
     internal var initializationError: Error?
     internal var asset: Asset? = nil
     private var reachability: Reachability?
+    internal var isPlaybackOffline: Bool = false
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
@@ -45,6 +46,7 @@ public class TPAVPlayer: AVPlayer {
         
         super.init()
         fetchAsset()
+        isPlaybackOffline = false
     }
     
     public init(offlineAssetId: String, completion: SetupCompletion? = nil) {
@@ -62,6 +64,7 @@ public class TPAVPlayer: AVPlayer {
             self.initializationError = TPStreamPlayerError.incompleteOfflineVideo
             self.initializationStatus = "error"
         }
+        isPlaybackOffline = true
     }
     
     private func fetchAsset() {

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -58,15 +58,23 @@ struct PlayerSettingsButton: View {
     }
     
     private func getMainActionSheetButtons() -> [ActionSheet.Button] {
-        var actionButtons: [ActionSheet.Button] = [playbackSpeedButton(), videoQualityButton()]
+        var actionButtons: [ActionSheet.Button] = [playbackSpeedButton()]
         
-        if playerConfig.showDownloadOption {
-            actionButtons.append(downloadQualityButton())
+        if !player.player.isPlaybackOffline {
+            addOnlinePlaybackButtons(to: &actionButtons)
         }
         
         actionButtons.append(.cancel())
         
         return actionButtons
+    }
+
+    private func addOnlinePlaybackButtons(to buttons: inout [ActionSheet.Button]) {
+        buttons.append(videoQualityButton())
+        
+        if playerConfig.showDownloadOption {
+            buttons.append(downloadQualityButton())
+        }
     }
     
     private func playbackSpeedButton() -> ActionSheet.Button {

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -150,12 +150,23 @@ class PlayerControlsUIView: UIView {
     @IBAction func showOptionsMenu(_ sender: Any) {
         let optionsMenu = UIAlertController(title: nil, message: nil, preferredStyle: ACTION_SHEET_PREFERRED_STYLE)
         optionsMenu.addAction(UIAlertAction(title: "Playback Speed", style: .default) { _ in self.showPlaybackSpeedMenu()})
-        optionsMenu.addAction(UIAlertAction(title: "Video Quality", style: .default, handler: { action in self.showVideoQualityMenu()}))
-        optionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        if playerConfig.showDownloadOption {
-            optionsMenu.addAction(UIAlertAction(title: "Download", style: .default, handler: { action in self.showDownloadQualityMenu()}))
+        if !player.player.isPlaybackOffline {
+            addOnlinePlaybackButtons(to: optionsMenu)
         }
+        optionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         parentViewController?.present(optionsMenu, animated: true, completion: nil)
+    }
+    
+    private func addOnlinePlaybackButtons(to menu: UIAlertController) {
+        menu.addAction(UIAlertAction(title: "Video Quality", style: .default) { _ in
+            self.showVideoQualityMenu()
+        })
+        
+        if playerConfig.showDownloadOption {
+            menu.addAction(UIAlertAction(title: "Download", style: .default) { _ in
+                self.showDownloadQualityMenu()
+            })
+        }
     }
     
     func showPlaybackSpeedMenu(){


### PR DESCRIPTION
- Added a new property `isPlaybackOffline` to differentiate between offline and online playback modes.
- Updated `PlayerSettingsButton` and `PlayerControlsUIView` to conditionally display video quality and download options only during online playback.
- Refactored the options menu to include online-specific settings when the player is not in offline mode.