### PR TITLE
refactor: Remove Placeholder StartDownload Method

### DIFF
--- a/Example/Views/PlayerView.swift
+++ b/Example/Views/PlayerView.swift
@@ -45,22 +45,7 @@ struct PlayerView: View {
                     .onDisappear {
                         player.pause()
                     }
-                Button(action: {
-                    startOfflineDownload()
-                }) {
-                    Text("Start Offline Download")
-                        .font(.headline)
-                        .padding()
-                        .foregroundColor(.white)
-                        .background(Color.blue)
-                        .cornerRadius(10)
-                    Spacer()
-                }
             }
         }
-    }
-    
-    func startOfflineDownload() {
-        TPStreamsDownloadManager.shared.startDownload(assetID: assetId!, accessToken: accessToken!, resolution: "240p")
     }
 }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -30,19 +30,6 @@ public final class TPStreamsDownloadManager {
         assetDownloadDelegate.tpStreamsDownloadDelegate = tpStreamsDownloadDelegate
     }
 
-    public func startDownload(assetID: String, accessToken: String, resolution: String) {
-        TPStreamsSDK.provider.API.getAsset(assetID, accessToken) { [weak self] asset, error in
-            guard let self = self else { return }
-            if let asset = asset {
-                //TODO Create video quality object (dummy for now, can be implemented later)
-                let videoQuality = VideoQuality.init(resolution: resolution, bitrate: 4611200)
-                startDownload(asset: asset, videoQuality: videoQuality)
-            } else if let error = error{
-                print (error)
-            }
-        }
-    }
-
     internal func startDownload(asset: Asset, videoQuality: VideoQuality) {
 
         if LocalOfflineAsset.manager.exists(id: asset.id) {


### PR DESCRIPTION
- Removed the startDownload method from TPStreamsDownloadManager.swift, which was added earlier as a placeholder for downloading functionality.