### PR TITLE
fix: Add drmContentId field in Video Model

### DIFF
--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -22,6 +22,7 @@ class LocalOfflineAsset: Object {
     @Persisted var bitRate: Double = 0.0
     @Persisted var size: Double = 0.0
     @Persisted var folderTree: String = ""
+    @Persisted var contentId: String? = nil
     
     static var manager = ObjectManager<LocalOfflineAsset>()
 }

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -22,7 +22,7 @@ class LocalOfflineAsset: Object {
     @Persisted var bitRate: Double = 0.0
     @Persisted var size: Double = 0.0
     @Persisted var folderTree: String = ""
-    @Persisted var contentId: String? = nil
+    @Persisted var drmContentId: String? = nil
     
     static var manager = ObjectManager<LocalOfflineAsset>()
 }

--- a/Source/Network/Models/Video.swift
+++ b/Source/Network/Models/Video.swift
@@ -12,5 +12,5 @@ struct Video{
     let status: String
     let drmEncrypted: Bool
     let duration: Double
-    let contentId: String?
+    let drmContentId: String?
 }

--- a/Source/Network/Models/Video.swift
+++ b/Source/Network/Models/Video.swift
@@ -12,4 +12,5 @@ struct Video{
     let status: String
     let drmEncrypted: Bool
     let duration: Double
+    let contentId: String?
 }

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -28,11 +28,12 @@ class StreamsAPIParser: APIParser {
               let playbackURL = videoDict["playback_url"] as? String,
               let status = videoDict["status"] as? String,
               let duration = videoDict["duration"] as? Double,
+              let contentId = videoDict["content_id"] as? String,
               let contentProtectionType = videoDict["content_protection_type"] as? String else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration, contentId: contentId)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -28,12 +28,12 @@ class StreamsAPIParser: APIParser {
               let playbackURL = videoDict["playback_url"] as? String,
               let status = videoDict["status"] as? String,
               let duration = videoDict["duration"] as? Double,
-              let contentId = videoDict["content_id"] as? String,
+              let drmContentId = videoDict["drm_content_id"] as? String,
               let contentProtectionType = videoDict["content_protection_type"] as? String else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration, contentId: contentId)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration, drmContentId: drmContentId)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/Network/Parsers/TestpressAPIParser.swift
+++ b/Source/Network/Parsers/TestpressAPIParser.swift
@@ -28,12 +28,12 @@ class TestpressAPIParser: APIParser {
               let playbackURL = videoDict["hls_url"] as? String ?? videoDict["url"] as? String,
               let status = videoDict["transcoding_status"] as? String,
               let duration = videoDict["duration"] as? Double,
-              let contentId = videoDict["content_id"] as? String,
+              let drmContentId = videoDict["drm_content_id"] as? String,
               let drmEncrypted = videoDict["drm_enabled"] as? Bool else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration, contentId: contentId)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration, drmContentId: drmContentId)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/Network/Parsers/TestpressAPIParser.swift
+++ b/Source/Network/Parsers/TestpressAPIParser.swift
@@ -28,11 +28,12 @@ class TestpressAPIParser: APIParser {
               let playbackURL = videoDict["hls_url"] as? String ?? videoDict["url"] as? String,
               let status = videoDict["transcoding_status"] as? String,
               let duration = videoDict["duration"] as? Double,
+              let contentId = videoDict["content_id"] as? String,
               let drmEncrypted = videoDict["drm_enabled"] as? Bool else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration, contentId: contentId)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {


### PR DESCRIPTION
- Added `drmContentId` property to the `Video` model and `LocalOfflineAsset` database entity.
- Updated API parsers (`StreamsAPIParser` and `TestpressAPIParser`) to handle `drm_content_id` field in API responses.
- This `drmContentId` is used to facilitate offline DRM license downloads for FairPlay-protected content.