### PR TITLE
refactor: Move `drmContentId` from Video to Asset Model

### DIFF
--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -14,6 +14,7 @@ struct Asset {
     let video: Video?
     let liveStream: LiveStream?
     let folderTree: String?
+    let drmContentId: String?
     
     var playbackURL: String? {
         if let video = video {

--- a/Source/Network/Models/Video.swift
+++ b/Source/Network/Models/Video.swift
@@ -12,5 +12,4 @@ struct Video{
     let status: String
     let drmEncrypted: Bool
     let duration: Double
-    let drmContentId: String?
 }

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -19,8 +19,9 @@ class StreamsAPIParser: APIParser {
         let video = parseVideo(from: responseDict["video"] as? [String: Any])
         let liveStream = parseLiveStream(from: responseDict["live_stream"] as? [String: Any])
         let folderTree = responseDict["folder_tree"] as? String
+        let drmContentId = responseDict["drm_content_id"] as? String
 
-        return Asset(id: id, title: title, contentType: contentType, video: video, liveStream: liveStream, folderTree: folderTree)
+        return Asset(id: id, title: title, contentType: contentType, video: video, liveStream: liveStream, folderTree: folderTree, drmContentId: drmContentId)
     }
 
     func parseVideo(from dictionary: [String: Any]?) -> Video? {
@@ -28,12 +29,11 @@ class StreamsAPIParser: APIParser {
               let playbackURL = videoDict["playback_url"] as? String,
               let status = videoDict["status"] as? String,
               let duration = videoDict["duration"] as? Double,
-              let drmContentId = videoDict["drm_content_id"] as? String,
               let contentProtectionType = videoDict["content_protection_type"] as? String else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration, drmContentId: drmContentId)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/Network/Parsers/TestpressAPIParser.swift
+++ b/Source/Network/Parsers/TestpressAPIParser.swift
@@ -19,8 +19,9 @@ class TestpressAPIParser: APIParser {
         let video = parseVideo(from: responseDict["video"] as? [String: Any])
         let liveStream = parseLiveStream(from: responseDict["live_stream"] as? [String: Any])
         let folderTree = responseDict["folder_tree"] as? String
+        let drmContentId = responseDict["drm_content_id"] as? String
         
-        return Asset(id: id, title: title, contentType: contentType, video: video, liveStream: liveStream, folderTree: folderTree)
+        return Asset(id: id, title: title, contentType: contentType, video: video, liveStream: liveStream, folderTree: folderTree, drmContentId: drmContentId)
     }
 
     func parseVideo(from dictionary: [String: Any]?) -> Video? {
@@ -28,12 +29,11 @@ class TestpressAPIParser: APIParser {
               let playbackURL = videoDict["hls_url"] as? String ?? videoDict["url"] as? String,
               let status = videoDict["transcoding_status"] as? String,
               let duration = videoDict["duration"] as? Double,
-              let drmContentId = videoDict["drm_content_id"] as? String,
               let drmEncrypted = videoDict["drm_enabled"] as? Bool else {
             return nil
         }
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration, drmContentId: drmContentId)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {


### PR DESCRIPTION
- Moved the `drmContentId` property from the Video model to the Asset model.
- Updated the `StreamsAPIParser` and `TestpressAPIParser` to parse and assign `drmContentId` at the Asset level.
- Removed the `drmContentId` property from the Video model to streamline DRM handling.