### PR TITLE
fix: Include UUID in Sentry events for better traceability

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -19,7 +19,7 @@ import M3U8Parser
 public typealias SetupCompletion = (Error?) -> Void
 public struct InitializationErrorContext {
     var error: Error
-    var sentryIssueId: UUID?
+    var sentryIssueId: String?
 }
 
 public class TPAVPlayer: AVPlayer {
@@ -27,7 +27,7 @@ public class TPAVPlayer: AVPlayer {
     internal var assetID: String?
     private var setupCompletion: SetupCompletion?
     private var resourceLoaderDelegate: ResourceLoaderDelegate?
-    public var onError: ((Error, UUID?) -> Void)?
+    public var onError: ((Error, String?) -> Void)?
     @objc internal dynamic var initializationStatus = "pending"
     internal var initializationErrorContext: InitializationErrorContext?
     internal var asset: Asset? = nil

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -166,7 +166,7 @@ public class TPStreamPlayerViewController: UIViewController {
         showError(error: errorContext.error, sentryIssueId: errorContext.sentryIssueId)
     }
     
-    private func showError(error: Error, sentryIssueId: UUID?) {
+    private func showError(error: Error, sentryIssueId: String?) {
         var message: String
         if let tpStreamPlayerError = error as? TPStreamPlayerError {
             message = "\(tpStreamPlayerError.message)\nError code: \(tpStreamPlayerError.code)"
@@ -175,7 +175,7 @@ public class TPStreamPlayerViewController: UIViewController {
         }
         
         if let sentryIssueId = sentryIssueId {
-            message += "\nPlayerId: \(sentryIssueId.uuidString)"
+            message += "\nPlayerId: \(sentryIssueId)"
         }
         
         showNotice(withMessage: message)

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -121,7 +121,8 @@ public class TPStreamPlayerViewController: UIViewController {
             if let status = change.newValue {
                 switch status {
                 case "error":
-                    self.showError(error: self.player!.initializationError!)
+                    let errorInfo = self.player!.initializationErrorContext!
+                    self.showError(error: errorInfo.error, sentryIssueId: errorInfo.sentryIssueId)
                 case "ready":
                     self.noticeView.isHidden = true
                     self.showLiveStreamNotice()
@@ -160,18 +161,23 @@ public class TPStreamPlayerViewController: UIViewController {
     }
     
     private func handlePlayerInitializationError() {
-        guard let player = player, let initializationError = player.initializationError else { return }
+        guard let player = player, let errorContext = player.initializationErrorContext else { return }
         
-        showError(error: initializationError)
+        showError(error: errorContext.error, sentryIssueId: errorContext.sentryIssueId)
     }
     
-    private func showError(error: Error) {
+    private func showError(error: Error, sentryIssueId: UUID?) {
         var message: String
         if let tpStreamPlayerError = error as? TPStreamPlayerError {
             message = "\(tpStreamPlayerError.message)\nError code: \(tpStreamPlayerError.code)"
         } else {
             message = error.localizedDescription
         }
+        
+        if let sentryIssueId = sentryIssueId {
+            message += "\nPlayerId: \(sentryIssueId.uuidString)"
+        }
+        
         showNotice(withMessage: message)
     }
     

--- a/Source/Utils/Sentry.swift
+++ b/Source/Utils/Sentry.swift
@@ -8,12 +8,12 @@
 import Foundation
 import Sentry
 
-func captureErrorInSentry(_ error: Error, _ assetID: String?, _ accessToken: String?) -> UUID {
-    let uuid = UUID()
+func captureErrorInSentry(_ error: Error, _ assetID: String?, _ accessToken: String?) -> String {
+    let uuid = generateRandomString()
     
     SentrySDK.capture(error: error) { scope in
         scope.setTag(value: assetID ?? "", key: "assetID")
-        scope.setTag(value: uuid.uuidString, key: "playerId")
+        scope.setTag(value: uuid, key: "playerId")
         
         let additionalInfo = [
             "accessToken": accessToken
@@ -22,4 +22,9 @@ func captureErrorInSentry(_ error: Error, _ assetID: String?, _ accessToken: Str
     }
     
     return uuid
+}
+
+func generateRandomString(length: Int = 11) -> String {
+    let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return String((0..<length).map { _ in characters.randomElement()! })
 }

--- a/Source/Utils/Sentry.swift
+++ b/Source/Utils/Sentry.swift
@@ -8,13 +8,18 @@
 import Foundation
 import Sentry
 
-func captureErrorInSentry(_ error: Error,_ assetID: String?, _ accessToken: String?) {
+func captureErrorInSentry(_ error: Error, _ assetID: String?, _ accessToken: String?) -> UUID {
+    let uuid = UUID()
+    
     SentrySDK.capture(error: error) { scope in
         scope.setTag(value: assetID ?? "", key: "assetID")
+        scope.setTag(value: uuid.uuidString, key: "playerId")
         
         let additionalInfo = [
             "accessToken": accessToken
         ]
         scope.setContext(value: additionalInfo, key: "Additional Info")
     }
+    
+    return uuid
 }

--- a/Source/ViewModels/TPStreamPlayerViewModel.swift
+++ b/Source/ViewModels/TPStreamPlayerViewModel.swift
@@ -55,7 +55,7 @@ class TPStreamPlayerViewModel: ObservableObject {
         self.setNoticeMessage(noticeMessage)
     }
     
-    func showError(error: Error, sentryIssueId: UUID?) {
+    func showError(error: Error, sentryIssueId: String?) {
         var message: String
         if let tpStreamPlayerError = error as? TPStreamPlayerError {
             message = "\(tpStreamPlayerError.message)\nError code: \(tpStreamPlayerError.code)"
@@ -64,7 +64,7 @@ class TPStreamPlayerViewModel: ObservableObject {
         }
         
         if let sentryIssueId = sentryIssueId {
-            message += "\nPlayerId: \(sentryIssueId.uuidString)"
+            message += "\nPlayerId: \(sentryIssueId)"
         }
     
         setNoticeMessage(message)

--- a/Source/ViewModels/TPStreamPlayerViewModel.swift
+++ b/Source/ViewModels/TPStreamPlayerViewModel.swift
@@ -19,12 +19,12 @@ class TPStreamPlayerViewModel: ObservableObject {
     init(player: TPAVPlayer) {
         self.player = player
         self.showLiveStreamNotice()
-        if let initializationError = player.initializationError {
-            showError(error: initializationError)
+        if let errorContext = player.initializationErrorContext {
+            showError(error: errorContext.error, sentryIssueId: errorContext.sentryIssueId)
         }
         setupPlayerStatusObserver(for: player)
-        self.player.onError = { [weak self] error in
-            self?.showError(error: error)
+        self.player.onError = { [weak self] error, sentryIssueId in
+            self?.showError(error: error, sentryIssueId: sentryIssueId)
         }
     }
     
@@ -35,7 +35,8 @@ class TPStreamPlayerViewModel: ObservableObject {
             if let status = change.newValue {
                 switch status {
                 case "error":
-                    self.showError(error: self.player.initializationError!)
+                    let errorContext = self.player.initializationErrorContext!
+                    self.showError(error: errorContext.error, sentryIssueId: errorContext.sentryIssueId)
                 case "ready":
                     self.noticeMessage = nil
                     self.showLiveStreamNotice()
@@ -54,13 +55,18 @@ class TPStreamPlayerViewModel: ObservableObject {
         self.setNoticeMessage(noticeMessage)
     }
     
-    func showError(error: Error) {
+    func showError(error: Error, sentryIssueId: UUID?) {
         var message: String
         if let tpStreamPlayerError = error as? TPStreamPlayerError {
             message = "\(tpStreamPlayerError.message)\nError code: \(tpStreamPlayerError.code)"
         } else {
             message = error.localizedDescription
         }
+        
+        if let sentryIssueId = sentryIssueId {
+            message += "\nPlayerId: \(sentryIssueId.uuidString)"
+        }
+    
         setNoticeMessage(message)
     }
     


### PR DESCRIPTION
- Added a UUID to the Sentry event context to improve error traceability. The UUID, along with the error message, is now displayed in the player view controller, enabling easy correlation with specific Sentry events.
- Modified the initialization error handling to store both the error and the Sentry issue ID. This allows the player to show the error and Sentry issue ID even if the player is assigned to the view controller after the error occurs.
