### PR TITLE
fix: Add Validation for Auth Token Based on Provider

### DIFF
--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -29,10 +29,17 @@ public class TPStreamsSDK {
         self.orgCode = orgCode
         self.provider = provider
         self.authToken = authToken
+        self.validateAuthToken()
         self.activateAudioSession()
         self.initializeSentry()
         self.initializeDatabase()
         self.removePartiallyDeletedVideos()
+    }
+    
+    private static func validateAuthToken() {
+        guard provider != .tpstreams || authToken == nil else {
+            fatalError("If the provider is .tpstreams, authToken must be nil.")
+        }
     }
     
     private static func activateAudioSession() {


### PR DESCRIPTION
- Introduced a `validateAuthToken()` method to ensure that when the provider is `.tpstreams`, the `authToken` must be `nil`.
- This validation prevents potential misconfigurations by enforcing correct usage of the `authToken` based on the provider.