### PR TITLE
fix: Improve Access Token and Auth Token Validation in TPAVPlayer

### DIFF
--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -9,9 +9,9 @@ import Foundation
 import AVFoundation
 
 class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
-    let accessToken: String
+    let accessToken: String?
     
-    init(accessToken: String) {
+    init(accessToken: String?) {
         self.accessToken = accessToken
         super.init()
     }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -41,11 +41,6 @@ public class TPAVPlayer: AVPlayer {
             fatalError("AssetID cannot be empty")
         }
 
-        if let authToken = TPStreamsSDK.authToken, !authToken.isEmpty,
-           let accessToken = accessToken, !accessToken.isEmpty {
-            fatalError("Can't use both the Access token and Auth token.")
-        }
-
         if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
             fatalError("AccessToken cannot be empty")
         }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -32,7 +32,7 @@ public class TPAVPlayer: AVPlayer {
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
@@ -40,6 +40,16 @@ public class TPAVPlayer: AVPlayer {
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
         }
+
+        if let authToken = TPStreamsSDK.authToken, !authToken.isEmpty,
+           let accessToken = accessToken, !accessToken.isEmpty {
+            fatalError("Can't use both the Access token and Auth token.")
+        }
+
+        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
+            fatalError("AccessToken cannot be empty")
+        }
+
         self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion


### PR DESCRIPTION
- Updated `accessToken` in `ResourceLoaderDelegate` and `TPAVPlayer` to be optional (`String?`). In `TPAVPlayer`, a check is added to raise an error if both the `accessToken` and the global `authToken` are missing. This improves flexibility while ensuring at least one token is provided.