### PR TITLE
fix: Make accessToken an Optional Field

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -44,7 +44,7 @@ public final class TPStreamsDownloadManager {
         return false
     }
 
-    internal func startDownload(asset: Asset, accessToken: String, videoQuality: VideoQuality) {
+    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality) {
         contentKeyDelegate.setAssetDetails(asset.id, accessToken, true)
         if LocalOfflineAsset.manager.exists(id: asset.id) {
             return

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -123,8 +123,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     }
     
     func requestCKC(_ spcData: Data, _ completion: @escaping(Data?, Error?) -> Void) {
-        guard let assetID = assetID,
-              let accessToken = accessToken else { return }
+        guard let assetID = assetID else { return }
         TPStreamsSDK.provider.API.getDRMLicense(assetID, accessToken, spcData, contentID!, forOfflinePlayback, completion)
     }
     

--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -9,9 +9,9 @@ import Foundation
 import AVFoundation
 
 class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
-    let accessToken: String
+    let accessToken: String?
     
-    init(accessToken: String) {
+    init(accessToken: String?) {
         self.accessToken = accessToken
         super.init()
     }

--- a/Source/Network/BaseAPI.swift
+++ b/Source/Network/BaseAPI.swift
@@ -19,8 +19,8 @@ class BaseAPI {
         fatalError("parser must be implemented by subclasses.")
     }
     
-    static func getAsset(_ assetID: String, _ accessToken: String, completion: @escaping (Asset?, Error?) -> Void) {
-        let url = URL(string: String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID, accessToken))!
+    static func getAsset(_ assetID: String, _ accessToken: String?, completion: @escaping (Asset?, Error?) -> Void) {
+        let url = URL(string: String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? ""))!
         
         let headers: HTTPHeaders = (TPStreamsSDK.authToken?.isEmpty == false) ? ["Authorization": "JWT \(TPStreamsSDK.authToken!)"] : [:]
         
@@ -35,8 +35,8 @@ class BaseAPI {
             }
     }
     
-    static func getDRMLicense(_ assetID: String, _ accessToken: String, _ spcData: Data, _ contentID: String, _ forOfflinePlayback: Bool, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
-        let url = URL(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID, accessToken, (forOfflinePlayback == true ? "true" : "false")))!
+    static func getDRMLicense(_ assetID: String, _ accessToken: String?, _ spcData: Data, _ contentID: String, _ forOfflinePlayback: Bool, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
+        let url = URL(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? "", (forOfflinePlayback == true ? "true" : "false")))!
         
         let parameters = [
             "spc": spcData.base64EncodedString(),

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -36,13 +36,17 @@ public class TPAVPlayer: AVPlayer {
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
         
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
+        }
+        
+        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
+            fatalError("AccessToken cannot be empty")
         }
         self.accessToken = accessToken
         self.assetID = assetID
@@ -73,7 +77,7 @@ public class TPAVPlayer: AVPlayer {
     }
     
     private func fetchAsset() {
-        TPStreamsSDK.provider.API.getAsset(assetID!, accessToken!) { [weak self] asset, error in
+        TPStreamsSDK.provider.API.getAsset(assetID!, accessToken) { [weak self] asset, error in
             guard let self = self else { return }
             
             if let asset = asset {

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -44,10 +44,6 @@ public class TPAVPlayer: AVPlayer {
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
         }
-        
-        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
-            fatalError("AccessToken cannot be empty")
-        }
         self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -127,7 +127,7 @@ struct PlayerSettingsButton: View {
         availableVideoQualities.remove(at: 0)
         return availableVideoQualities.map { downloadQuality in
                 .default(Text(downloadQuality.resolution)) {
-                    TPStreamsDownloadManager.shared.startDownload(asset: player.asset!,accessToken: player.player.accessToken!, videoQuality: downloadQuality)
+                    TPStreamsDownloadManager.shared.startDownload(asset: player.asset!,accessToken: player.player.accessToken, videoQuality: downloadQuality)
                 }
         }
     }

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -244,7 +244,7 @@ class PlayerControlsUIView: UIView {
     
     func createActionForDownload(_ quality: VideoQuality) -> UIAlertAction {
         let action = UIAlertAction(title: quality.resolution, style: .default, handler: { (_) in
-            TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, accessToken: self.player.player.accessToken!, videoQuality: quality)
+            TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, accessToken: self.player.player.accessToken, videoQuality: quality)
         })
 
         return action


### PR DESCRIPTION
- Users can now access videos without an access token by providing an auth token.
- This commit makes the `accessToken` an optional field wherever required across all relevant areas.