### PR TITLE
fix: Raise error if access token not provided during initialization

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -44,6 +44,10 @@ public class TPAVPlayer: AVPlayer {
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
         }
+        
+        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
+            fatalError("AccessToken cannot be nil or empty")
+        }
         self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -44,6 +44,10 @@ public class TPAVPlayer: AVPlayer {
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
         }
+        
+        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
+            fatalError("AccessToken cannot be empty")
+        }
         self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -44,10 +44,6 @@ public class TPAVPlayer: AVPlayer {
         if assetID.isEmpty {
             fatalError("AssetID cannot be empty")
         }
-        
-        if (TPStreamsSDK.authToken?.isEmpty ?? true) && (accessToken?.isEmpty ?? true) {
-            fatalError("AccessToken cannot be empty")
-        }
         self.accessToken = accessToken
         self.assetID = assetID
         self.setupCompletion = completion


### PR DESCRIPTION
-  Raised an error if both authToken and accessToken are missing during player initialization. If the authToken is already set, the accessToken becomes optional, ensuring proper initialization without unnecessary constraints.