### PR TITLE
fix: App crash while running in Simulator

### DIFF
--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -127,7 +127,11 @@ struct PlayerSettingsButton: View {
         availableVideoQualities.remove(at: 0)
         return availableVideoQualities.map { downloadQuality in
                 .default(Text(downloadQuality.resolution)) {
-                    TPStreamsDownloadManager.shared.startDownload(asset: player.asset!,accessToken: player.player.accessToken, videoQuality: downloadQuality)
+                    do {
+                        try TPStreamsDownloadManager.shared.startDownload(asset: player.asset!, accessToken: player.player.accessToken, videoQuality: downloadQuality)
+                    } catch {
+                        print("Error downloading video: \(error)")
+                    }
                 }
         }
     }

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -244,7 +244,11 @@ class PlayerControlsUIView: UIView {
     
     func createActionForDownload(_ quality: VideoQuality) -> UIAlertAction {
         let action = UIAlertAction(title: quality.resolution, style: .default, handler: { (_) in
-            TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, accessToken: self.player.player.accessToken, videoQuality: quality)
+            do {
+                try TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, accessToken: self.player.player.accessToken, videoQuality: quality)
+            } catch {
+                print("Error downloading video: \(error)")
+            }
         })
 
         return action

--- a/StoryboardExample/MainViewController.swift
+++ b/StoryboardExample/MainViewController.swift
@@ -24,7 +24,7 @@ class MainViewController: UIViewController {
     }
     
     @IBAction func sample3Tapped(_ sender: UIButton) {
-        presentPlayerViewController(assistId: "9JRmKJXZSMe", accessToken: "1ae5e10e-fc85-4aa9-9a0a-6c195e9b0034")
+        presentPlayerViewController(assistId: "AgAFNEJn3kt", accessToken: "f9b11692-78c5-4d14-9385-5f1efb0b8f4e")
     }
     
     @IBAction func downloadsTapped(_ sender: UIButton) {


### PR DESCRIPTION
- The app was crashing when running in the iOS Simulator due to the usage of AVContentKeySession in SDK initialization, which is not supported in simulator environments.
- This has been resolved by conditionally initializing DRM-related components using compiler directives, ensuring they are only created on real devices while allowing non-DRM download functionality to work normally in the simulator. The fix maintains full DRM support on physical devices while enabling development and testing of download features in the simulator environment.