### PR TITLE
fix: Update Realm Swift to version 10.54.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "8.36.0")),
     .package(url: "https://github.com/M3U8Kit/M3U8Parser", .upToNextMajor(from: "1.1.0")),
     .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMajor(from: "5.2.2")),
-    .package(url: "https://github.com/realm/realm-swift", exact: "10.45.0")
+    .package(url: "https://github.com/realm/realm-swift", exact: "10.54.2")
   ],
 
   targets: [

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'Alamofire', '~> 5.9.0'
   spec.dependency 'M3U8Kit', '~> 1.1.0'
   spec.dependency 'ReachabilitySwift', '~> 5.2.2'
-  spec.dependency 'RealmSwift', '~> 10.45.0'
+  spec.dependency 'RealmSwift', '~> 10.54.2'
 
   spec.pod_target_xcconfig = {
     'OTHER_SWIFT_FLAGS[config=Debug]' => '-DCocoaPods',

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		03CE75022A7A337B00B84304 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CE75012A7A337B00B84304 /* UIView.swift */; };
 		03D7F4252C21C64D00DF3597 /* LiveIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */; };
 		03D7F4282C22C4F900DF3597 /* PlaybackSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4272C22C4F900DF3597 /* PlaybackSpeed.swift */; };
+		2DD12A212D4CF75400272433 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8E6389BC2A2724D000306FA4 /* TPStreamPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */; };
 		8E6389C42A27277D00306FA4 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389C32A27277D00306FA4 /* ExampleApp.swift */; };
 		8E6389C62A27277D00306FA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389C52A27277D00306FA4 /* ContentView.swift */; };
@@ -75,7 +76,6 @@
 		D92E48AD2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48AC2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift */; };
 		D92E48B62CAFBD6F00B1FAC3 /* ObjectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48B52CAFBD6F00B1FAC3 /* ObjectManager.swift */; };
 		D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E48D52CAFCD2400B1FAC3 /* OfflineAsset.swift */; };
-		D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F02CB0226A00B1FAC3 /* Realm */; };
 		D92E48F32CB0226A00B1FAC3 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; };
 		D960A8FB2CEDEE7C003B0B04 /* M3U8Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D960A8FA2CEDEE7C003B0B04 /* M3U8Parser.swift */; };
 		D9846D552CB406D000BFA875 /* AppDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9846D542CB406D000BFA875 /* AppDownloadManager.swift */; };
@@ -147,10 +147,11 @@
 		};
 		D92E48B42CAFBD2F00B1FAC3 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				2DD12A212D4CF75400272433 /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -261,7 +262,6 @@
 				0394CA312B5E5529006BED3B /* Reachability in Frameworks */,
 				8E6389E52A275B2A00306FA4 /* Alamofire in Frameworks */,
 				0326BADB2A335911009ABC58 /* Sentry in Frameworks */,
-				D92E48F12CB0226A00B1FAC3 /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -622,7 +622,6 @@
 				0326BADA2A335911009ABC58 /* Sentry */,
 				0326BADD2A348690009ABC58 /* M3U8Parser */,
 				0394CA302B5E5529006BED3B /* Reachability */,
-				D92E48F02CB0226A00B1FAC3 /* Realm */,
 				D92E48F22CB0226A00B1FAC3 /* RealmSwift */,
 			);
 			productName = iOSPlayerSDK;
@@ -655,7 +654,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1430;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					03B8FD8C2A690CAA00DAB7AE = {
 						CreatedOnToolsVersion = 14.3;
@@ -1114,7 +1113,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1149,7 +1149,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1305,7 +1305,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 10.45.0;
+				version = 10.54.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1330,11 +1330,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8E6389E32A275B2A00306FA4 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
-		};
-		D92E48F02CB0226A00B1FAC3 /* Realm */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D92E48EF2CB0226A00B1FAC3 /* XCRemoteSwiftPackageReference "realm-swift" */;
-			productName = Realm;
 		};
 		D92E48F22CB0226A00B1FAC3 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
- Bumped Realm Swift dependency from version 10.45.0 to 10.54.2 in Package.swift, TPStreamsSDK.podspec, and Xcode project configuration
- Updated Code sign property and Xcode configuration to support the latest Realm package, as they have changed the package from static to dynamic