### PR TITLE
fix: Playback failure while playing Testpress AES-encrypted video

### DIFF
--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -34,6 +34,9 @@ class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
     
     func appendAccessToken(_ url: URL) -> URL? {
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: true){
+            if TPStreamsSDK.provider == .testpress, let orgCode = TPStreamsSDK.orgCode {
+                components.host = "\(orgCode).testpress.in"
+            }
             let accessTokenQueryItem = URLQueryItem(name: "access_token", value: self.accessToken)
             components.queryItems = (components.queryItems ?? []) + [accessTokenQueryItem]
             return components.url

--- a/Source/Managers/ResourceLoaderDelegate.swift
+++ b/Source/Managers/ResourceLoaderDelegate.swift
@@ -34,7 +34,7 @@ class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
     
     func appendAccessToken(_ url: URL) -> URL? {
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: true){
-            if TPStreamsSDK.provider == .testpress, let orgCode = TPStreamsSDK.orgCode {
+            if TPStreamsSDK.provider == .testpress, let orgCode = TPStreamsSDK.orgCode, !orgCode.isEmpty {
                 components.host = "\(orgCode).testpress.in"
             }
             let accessTokenQueryItem = URLQueryItem(name: "access_token", value: self.accessToken)


### PR DESCRIPTION
- Videos from Testpress were failing to load because the encryption key URL had an incorrect host, causing the request to go to the wrong domain.
- This happened when the original URL's host wasn’t replaced with the appropriate org-specific Testpress domain `{orgCode}.testpress.in`.
- This is fixed by updating the host in the encryption key URL when the provider is Testpress and a valid orgCode is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling to ensure the correct host is used when appending access tokens under specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->