### PR TITLE
feat: Add thumbnail URL support for offline assets

### DIFF
--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -14,12 +14,12 @@ public struct OfflineAsset: Hashable {
     public var srcURL: String = ""
     public var downloadedAt = Date()
     public var status:String = Status.notStarted.rawValue
-    public var thumbnailURL: String? = nil
     public var percentageCompleted: Double = 0.0
     public var resolution: String = ""
     public var duration: Double = 0.0
     public var bitRate: Double = 0.0
     public var size: Double = 0.0
+    public var thumbnailURL: String? = nil
     public var folderTree: String = ""
 }
 

--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -14,6 +14,7 @@ public struct OfflineAsset: Hashable {
     public var srcURL: String = ""
     public var downloadedAt = Date()
     public var status:String = Status.notStarted.rawValue
+    public var thumbnailURL: String? = nil
     public var percentageCompleted: Double = 0.0
     public var resolution: String = ""
     public var duration: Double = 0.0

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -60,6 +60,7 @@ extension LocalOfflineAsset {
             title: self.title,
             downloadedAt: self.downloadedAt,
             status: self.status,
+            thumbnailURL: self.thumbnailURL,
             percentageCompleted: self.percentageCompleted,
             resolution: self.resolution,
             duration: self.duration,

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -16,6 +16,7 @@ class LocalOfflineAsset: Object {
     @Persisted var downloadedPath: String = ""
     @Persisted var downloadedAt = Date()
     @Persisted var status:String = Status.notStarted.rawValue
+    @Persisted var thumbnailURL: String? = nil
     @Persisted var percentageCompleted: Double = 0.0
     @Persisted var resolution: String = ""
     @Persisted var duration: Double = 0.0
@@ -80,7 +81,8 @@ extension LocalOfflineAsset {
             playbackURL: playbackURLString,
             status: self.status,
             drmEncrypted: isDrmEncrypted,
-            duration: self.duration
+            duration: self.duration,
+            thumbnailURL: self.thumbnailURL
         )
 
         let asset: Asset = Asset(

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -37,6 +37,7 @@ extension LocalOfflineAsset {
         resolution: String,
         duration:Double,
         bitRate: Double,
+        thumbnailURL: String? = nil,
         folderTree: String,
         drmContentId: String? = nil
     ) -> LocalOfflineAsset {
@@ -48,6 +49,7 @@ extension LocalOfflineAsset {
         localOfflineAsset.duration = duration
         localOfflineAsset.bitRate = bitRate
         localOfflineAsset.size = (bitRate * duration)
+        localOfflineAsset.thumbnailURL = thumbnailURL
         localOfflineAsset.folderTree = folderTree
         localOfflineAsset.drmContentId = drmContentId
         return localOfflineAsset
@@ -60,12 +62,12 @@ extension LocalOfflineAsset {
             title: self.title,
             downloadedAt: self.downloadedAt,
             status: self.status,
-            thumbnailURL: self.thumbnailURL,
             percentageCompleted: self.percentageCompleted,
             resolution: self.resolution,
             duration: self.duration,
             bitRate: self.bitRate,
             size: self.size,
+            thumbnailURL: self.thumbnailURL,
             folderTree: self.folderTree
         )
     }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -61,6 +61,9 @@ public final class TPStreamsDownloadManager {
             return
         }
         
+        print("TPStreamsDownloadManager: Starting download for asset \(asset.id)")
+        print("TPStreamsDownloadManager: Asset thumbnail URL: \(asset.video?.thumbnailURL ?? "nil")")
+        
         let avUrlAsset = AVURLAsset(url: URL(string: asset.video!.playbackURL)!)
 
         guard let task = assetDownloadURLSession.aggregateAssetDownloadTask(
@@ -78,6 +81,7 @@ public final class TPStreamsDownloadManager {
             resolution:videoQuality.resolution,
             duration: asset.video!.duration,
             bitRate: videoQuality.bitrate,
+            thumbnailURL: asset.video!.thumbnailURL ?? "",
             folderTree: asset.folderTree ?? "",
             drmContentId: asset.drmContentId
         )

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -61,9 +61,6 @@ public final class TPStreamsDownloadManager {
             return
         }
         
-        print("TPStreamsDownloadManager: Starting download for asset \(asset.id)")
-        print("TPStreamsDownloadManager: Asset thumbnail URL: \(asset.video?.thumbnailURL ?? "nil")")
-        
         let avUrlAsset = AVURLAsset(url: URL(string: asset.video!.playbackURL)!)
 
         guard let task = assetDownloadURLSession.aggregateAssetDownloadTask(

--- a/Source/Network/Models/Video.swift
+++ b/Source/Network/Models/Video.swift
@@ -12,4 +12,5 @@ struct Video{
     let status: String
     let drmEncrypted: Bool
     let duration: Double
+    let thumbnailURL: String?
 }

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -33,8 +33,9 @@ class StreamsAPIParser: APIParser {
         }
         
         let duration: Double = videoDict["duration"] as? Double ?? 0.0
+        let thumbnailURL: String? = videoDict["cover_thumbnail_url"] as? String
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: contentProtectionType == "drm", duration: duration, thumbnailURL: thumbnailURL)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/Network/Parsers/TestpressAPIParser.swift
+++ b/Source/Network/Parsers/TestpressAPIParser.swift
@@ -33,7 +33,7 @@ class TestpressAPIParser: APIParser {
         }
         let duration: Double = videoDict["duration"] as? Double ?? 0.0
         
-        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration)
+        return Video(playbackURL: playbackURL, status: status, drmEncrypted: drmEncrypted, duration: duration, thumbnailURL: nil)
     }
 
     func parseLiveStream(from dictionary: [String: Any]?) -> LiveStream? {

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -67,7 +67,7 @@ public class TPStreamsSDK {
     }
     
     private static func initializeDatabase() {
-        var config = Realm.Configuration(schemaVersion: 1)
+        var config = Realm.Configuration(schemaVersion: 2)
         config.fileURL!.deleteLastPathComponent()
         config.fileURL!.appendPathComponent("TPStreamsPlayerSDK")
         config.fileURL!.appendPathExtension("realm")

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -67,7 +67,15 @@ public class TPStreamsSDK {
     }
     
     private static func initializeDatabase() {
-        var config = Realm.Configuration(schemaVersion: 2)
+        var config = Realm.Configuration(
+            schemaVersion: 2,
+            migrationBlock: { migration, oldSchemaVersion in
+                if oldSchemaVersion < 2 {
+                        // No manual migration needed.
+                        // Realm automatically handles newly added optional properties.
+                }
+            }
+        )
         config.fileURL!.deleteLastPathComponent()
         config.fileURL!.appendPathComponent("TPStreamsPlayerSDK")
         config.fileURL!.appendPathExtension("realm")


### PR DESCRIPTION
- iOS SDK offline assets did not include thumbnail URL, creating inconsistency with Android and React Native.
- Added thumbnail URL support to ensure consistent download(offlineAsset) details across platforms.