### PR TITLE
feat: Add metadata support for offline assets

### DIFF
--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -21,9 +21,17 @@ public struct OfflineAsset: Hashable {
     public var size: Double = 0.0
     public var thumbnailURL: String? = nil
     public var folderTree: String = ""
-    public var metadata: [String: String]? = nil
-}
+    public var metadata: [String: Any]? = nil
 
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(assetId)
+    }
+
+    public static func == (lhs: OfflineAsset, rhs: OfflineAsset) -> Bool {
+        return lhs.assetId == rhs.assetId
+    }
+
+}
 
 public enum Status: String {
     case notStarted = "notStarted"

--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -21,6 +21,7 @@ public struct OfflineAsset: Hashable {
     public var size: Double = 0.0
     public var thumbnailURL: String? = nil
     public var folderTree: String = ""
+    public var metadataJSON: String? = nil
 }
 
 

--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -21,7 +21,7 @@ public struct OfflineAsset: Hashable {
     public var size: Double = 0.0
     public var thumbnailURL: String? = nil
     public var folderTree: String = ""
-    public var metadataJSON: String? = nil
+    public var metadata: [String: String]? = nil
 }
 
 

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -24,9 +24,13 @@ class LocalOfflineAsset: Object {
     @Persisted var size: Double = 0.0
     @Persisted var folderTree: String = ""
     @Persisted var drmContentId: String? = nil
-    @Persisted var metadataJSON: String? = nil
+    @Persisted var metadataMap = Map<String, String>()
     
     static var manager = ObjectManager<LocalOfflineAsset>()
+    
+    var metadata: [String: String] {
+        Dictionary(uniqueKeysWithValues: metadataMap.map { ($0.key, $0.value) })
+    }
 }
 
 extension LocalOfflineAsset {
@@ -41,7 +45,7 @@ extension LocalOfflineAsset {
         thumbnailURL: String? = nil,
         folderTree: String,
         drmContentId: String? = nil,
-        metadata: String? = nil
+        metadata: [String: String]? = nil
     ) -> LocalOfflineAsset {
         let localOfflineAsset = LocalOfflineAsset()
         localOfflineAsset.assetId = assetId
@@ -54,7 +58,9 @@ extension LocalOfflineAsset {
         localOfflineAsset.thumbnailURL = thumbnailURL
         localOfflineAsset.folderTree = folderTree
         localOfflineAsset.drmContentId = drmContentId
-        localOfflineAsset.metadataJSON = metadata
+        metadata?.forEach { key, value in
+            localOfflineAsset.metadataMap[key] = value
+        }
         return localOfflineAsset
     }
     
@@ -72,7 +78,7 @@ extension LocalOfflineAsset {
             size: self.size,
             thumbnailURL: self.thumbnailURL,
             folderTree: self.folderTree,
-            metadataJSON: self.metadataJSON
+            metadata: self.metadata
         )
     }
     

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -126,35 +126,3 @@ extension LocalOfflineAsset {
         return nil
     }
 }
-
-
-extension AnyRealmValue {
-    init(fromAny value: Any) {
-        switch value {
-        case let v as String: self = .string(v)
-        case let v as Int: self = .int(v)
-        case let v as Double: self = .double(v)
-        case let v as Float: self = .float(v)
-        case let v as Bool: self = .bool(v)
-        case let v as Date: self = .date(v)
-        case let v as Data: self = .data(v)
-        case is NSNull: self = .none
-        default:
-            self = .string(String(describing: value))
-        }
-    }
-
-    var toAny: Any {
-        switch self {
-        case .string(let v): return v
-        case .int(let v): return v
-        case .double(let v): return v
-        case .float(let v): return v
-        case .bool(let v): return v
-        case .date(let v): return v
-        case .data(let v): return v
-        case .none: return NSNull()
-        @unknown default: return NSNull()
-        }
-    }
-}

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -24,6 +24,7 @@ class LocalOfflineAsset: Object {
     @Persisted var size: Double = 0.0
     @Persisted var folderTree: String = ""
     @Persisted var drmContentId: String? = nil
+    @Persisted var metadataJSON: String? = nil
     
     static var manager = ObjectManager<LocalOfflineAsset>()
 }
@@ -39,7 +40,8 @@ extension LocalOfflineAsset {
         bitRate: Double,
         thumbnailURL: String? = nil,
         folderTree: String,
-        drmContentId: String? = nil
+        drmContentId: String? = nil,
+        metadata: String? = nil
     ) -> LocalOfflineAsset {
         let localOfflineAsset = LocalOfflineAsset()
         localOfflineAsset.assetId = assetId
@@ -52,6 +54,7 @@ extension LocalOfflineAsset {
         localOfflineAsset.thumbnailURL = thumbnailURL
         localOfflineAsset.folderTree = folderTree
         localOfflineAsset.drmContentId = drmContentId
+        localOfflineAsset.metadataJSON = metadata
         return localOfflineAsset
     }
     
@@ -68,7 +71,8 @@ extension LocalOfflineAsset {
             bitRate: self.bitRate,
             size: self.size,
             thumbnailURL: self.thumbnailURL,
-            folderTree: self.folderTree
+            folderTree: self.folderTree,
+            metadataJSON: self.metadataJSON
         )
     }
     

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -78,7 +78,7 @@ public final class TPStreamsDownloadManager {
             resolution:videoQuality.resolution,
             duration: asset.video!.duration,
             bitRate: videoQuality.bitrate,
-            thumbnailURL: asset.video!.thumbnailURL,
+            thumbnailURL: asset.video!.thumbnailURL ?? "",
             folderTree: asset.folderTree ?? "",
             drmContentId: asset.drmContentId,
             metadata: metadata

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -47,7 +47,7 @@ public final class TPStreamsDownloadManager {
         return false
     }
 
-    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: String? = nil) throws {
+    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: [String: String]? = nil) throws {
         #if targetEnvironment(simulator)
             if (asset.video?.drmEncrypted == true){
                 print("Downloading DRM content is not supported in simulator")

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -47,7 +47,7 @@ public final class TPStreamsDownloadManager {
         return false
     }
 
-    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality) throws {
+    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: String? = nil) throws {
         #if targetEnvironment(simulator)
             if (asset.video?.drmEncrypted == true){
                 print("Downloading DRM content is not supported in simulator")
@@ -78,9 +78,10 @@ public final class TPStreamsDownloadManager {
             resolution:videoQuality.resolution,
             duration: asset.video!.duration,
             bitRate: videoQuality.bitrate,
-            thumbnailURL: asset.video!.thumbnailURL ?? "",
+            thumbnailURL: asset.video!.thumbnailURL,
             folderTree: asset.folderTree ?? "",
-            drmContentId: asset.drmContentId
+            drmContentId: asset.drmContentId,
+            metadata: metadata
         )
         LocalOfflineAsset.manager.add(object: localOfflineAsset)
         assetDownloadDelegate.activeDownloadsMap[task] = localOfflineAsset

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -47,7 +47,7 @@ public final class TPStreamsDownloadManager {
         return false
     }
 
-    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: [String: String]? = nil) throws {
+    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: [String: Any]? = nil) throws {
         #if targetEnvironment(simulator)
             if (asset.video?.drmEncrypted == true){
                 print("Downloading DRM content is not supported in simulator")

--- a/Source/Extensions/AnyRealmValue.swift
+++ b/Source/Extensions/AnyRealmValue.swift
@@ -1,0 +1,33 @@
+import Foundation
+import RealmSwift
+
+extension AnyRealmValue {
+    init(fromAny value: Any) {
+        switch value {
+        case let v as String: self = .string(v)
+        case let v as Int: self = .int(v)
+        case let v as Double: self = .double(v)
+        case let v as Float: self = .float(v)
+        case let v as Bool: self = .bool(v)
+        case let v as Date: self = .date(v)
+        case let v as Data: self = .data(v)
+        case is NSNull: self = .none
+        default:
+            self = .string(String(describing: value))
+        }
+    }
+
+    var toAny: Any {
+        switch self {
+        case .string(let v): return v
+        case .int(let v): return v
+        case .double(let v): return v
+        case .float(let v): return v
+        case .bool(let v): return v
+        case .date(let v): return v
+        case .data(let v): return v
+        case .none: return NSNull()
+        @unknown default: return NSNull()
+        }
+    }
+}

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -33,11 +33,11 @@ public class TPAVPlayer: AVPlayer {
     internal var asset: Asset? = nil
     private var reachability: Reachability?
     internal var isPlaybackOffline: Bool = false
-    internal var metadata: [String: String]? = nil
+    internal var metadata: [String: Any]? = nil
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String? = nil, metadata: [String: String]? = nil, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, metadata: [String: Any]? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -33,11 +33,11 @@ public class TPAVPlayer: AVPlayer {
     internal var asset: Asset? = nil
     private var reachability: Reachability?
     internal var isPlaybackOffline: Bool = false
-    internal var metadata: String? = nil
+    internal var metadata: [String: String]? = nil
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String? = nil, metadata: String? = nil, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, metadata: [String: String]? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
@@ -60,14 +60,14 @@ public class TPAVPlayer: AVPlayer {
         isPlaybackOffline = false
     }
     
-    public init(offlineAssetId: String, metadata: String? = nil, completion: SetupCompletion? = nil) {
+    public init(offlineAssetId: String, metadata: [String: String]? = nil, completion: SetupCompletion? = nil) {
         self.setupCompletion = completion
         super.init()
         isPlaybackOffline = true
         guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: offlineAssetId) else { return }
         if (localOfflineAsset.status == "finished") {
             self.asset = localOfflineAsset.asAsset()
-            self.metadata = localOfflineAsset.metadataJSON
+            self.metadata = localOfflineAsset.metadata
             self.initializePlayer()
             self.setupCompletion?(nil)
             self.initializationStatus = "ready"

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -33,11 +33,10 @@ public class TPAVPlayer: AVPlayer {
     internal var asset: Asset? = nil
     private var reachability: Reachability?
     internal var isPlaybackOffline: Bool = false
-    internal var metadata: [String: Any]? = nil
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String? = nil, metadata: [String: Any]? = nil, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
@@ -53,7 +52,6 @@ public class TPAVPlayer: AVPlayer {
         self.assetID = assetID
         self.setupCompletion = completion
         self.resourceLoaderDelegate = ResourceLoaderDelegate(accessToken: accessToken)
-        self.metadata = metadata
         
         super.init()
         fetchAsset()

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -60,14 +60,13 @@ public class TPAVPlayer: AVPlayer {
         isPlaybackOffline = false
     }
     
-    public init(offlineAssetId: String, metadata: [String: String]? = nil, completion: SetupCompletion? = nil) {
+    public init(offlineAssetId: String, completion: SetupCompletion? = nil) {
         self.setupCompletion = completion
         super.init()
         isPlaybackOffline = true
         guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: offlineAssetId) else { return }
         if (localOfflineAsset.status == "finished") {
             self.asset = localOfflineAsset.asAsset()
-            self.metadata = localOfflineAsset.metadata
             self.initializePlayer()
             self.setupCompletion?(nil)
             self.initializationStatus = "ready"

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -33,10 +33,11 @@ public class TPAVPlayer: AVPlayer {
     internal var asset: Asset? = nil
     private var reachability: Reachability?
     internal var isPlaybackOffline: Bool = false
+    internal var metadata: String? = nil
     
     public var availableVideoQualities: [VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
-    public init(assetID: String, accessToken: String? = nil, completion: SetupCompletion? = nil) {
+    public init(assetID: String, accessToken: String? = nil, metadata: String? = nil, completion: SetupCompletion? = nil) {
         guard TPStreamsSDK.orgCode != nil else {
             fatalError("You must call TPStreamsSDK.initialize")
         }
@@ -52,19 +53,21 @@ public class TPAVPlayer: AVPlayer {
         self.assetID = assetID
         self.setupCompletion = completion
         self.resourceLoaderDelegate = ResourceLoaderDelegate(accessToken: accessToken)
+        self.metadata = metadata
         
         super.init()
         fetchAsset()
         isPlaybackOffline = false
     }
     
-    public init(offlineAssetId: String, completion: SetupCompletion? = nil) {
+    public init(offlineAssetId: String, metadata: String? = nil, completion: SetupCompletion? = nil) {
         self.setupCompletion = completion
         super.init()
         isPlaybackOffline = true
         guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: offlineAssetId) else { return }
         if (localOfflineAsset.status == "finished") {
             self.asset = localOfflineAsset.asAsset()
+            self.metadata = metadata ?? localOfflineAsset.metadataJSON
             self.initializePlayer()
             self.setupCompletion?(nil)
             self.initializationStatus = "ready"

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -67,7 +67,7 @@ public class TPAVPlayer: AVPlayer {
         guard let localOfflineAsset = LocalOfflineAsset.manager.get(id: offlineAssetId) else { return }
         if (localOfflineAsset.status == "finished") {
             self.asset = localOfflineAsset.asAsset()
-            self.metadata = metadata ?? localOfflineAsset.metadataJSON
+            self.metadata = localOfflineAsset.metadataJSON
             self.initializePlayer()
             self.setupCompletion?(nil)
             self.initializationStatus = "ready"

--- a/Source/TPStreamPlayerConfiguration.swift
+++ b/Source/TPStreamPlayerConfiguration.swift
@@ -14,6 +14,7 @@ public struct TPStreamPlayerConfiguration {
     public var watchedProgressTrackColor: UIColor = .red
     public var progressBarThumbColor: UIColor = .red
     public var showDownloadOption: Bool = false
+    public var downloadMetadata: [String: Any]? = nil
 }
 
 
@@ -46,6 +47,11 @@ public class TPStreamPlayerConfigurationBuilder {
     
     public func showDownloadOption() -> Self {
         configuration.showDownloadOption = true
+        return self
+    }
+    
+    public func setDownloadMetadata(_ metadata: [String: Any]?) -> Self {
+        configuration.downloadMetadata = metadata
         return self
     }
     

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -68,9 +68,9 @@ public class TPStreamsSDK {
     
     private static func initializeDatabase() {
         var config = Realm.Configuration(
-            schemaVersion: 2,
+            schemaVersion: 3,
             migrationBlock: { migration, oldSchemaVersion in
-                if oldSchemaVersion < 2 {
+                if oldSchemaVersion < 3 {
                         // No manual migration needed.
                         // Realm automatically handles newly added optional properties.
                 }

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -132,7 +132,7 @@ struct PlayerSettingsButton: View {
                             asset: player.asset!, 
                             accessToken: player.player.accessToken, 
                             videoQuality: downloadQuality,
-                            metadata: player.player.metadata
+                            metadata: playerConfig.downloadMetadata
                         )
                     } catch {
                         print("Error downloading video: \(error)")

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -128,7 +128,12 @@ struct PlayerSettingsButton: View {
         return availableVideoQualities.map { downloadQuality in
                 .default(Text(downloadQuality.resolution)) {
                     do {
-                        try TPStreamsDownloadManager.shared.startDownload(asset: player.asset!, accessToken: player.player.accessToken, videoQuality: downloadQuality)
+                        try TPStreamsDownloadManager.shared.startDownload(
+                            asset: player.asset!, 
+                            accessToken: player.player.accessToken, 
+                            videoQuality: downloadQuality,
+                            metadata: player.player.metadata
+                        )
                     } catch {
                         print("Error downloading video: \(error)")
                     }

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -249,7 +249,7 @@ class PlayerControlsUIView: UIView {
                     asset: self.player.asset!, 
                     accessToken: self.player.player.accessToken, 
                     videoQuality: quality,
-                    metadata: self.player.player.metadata
+                    metadata: self.playerConfig.downloadMetadata
                 )
             } catch {
                 print("Error downloading video: \(error)")

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -245,7 +245,12 @@ class PlayerControlsUIView: UIView {
     func createActionForDownload(_ quality: VideoQuality) -> UIAlertAction {
         let action = UIAlertAction(title: quality.resolution, style: .default, handler: { (_) in
             do {
-                try TPStreamsDownloadManager.shared.startDownload(asset: self.player.asset!, accessToken: self.player.player.accessToken, videoQuality: quality)
+                try TPStreamsDownloadManager.shared.startDownload(
+                    asset: self.player.asset!, 
+                    accessToken: self.player.player.accessToken, 
+                    videoQuality: quality,
+                    metadata: self.player.player.metadata
+                )
             } catch {
                 print("Error downloading video: \(error)")
             }

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		03D7F4252C21C64D00DF3597 /* LiveIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */; };
 		03D7F4282C22C4F900DF3597 /* PlaybackSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4272C22C4F900DF3597 /* PlaybackSpeed.swift */; };
 		2DD12A212D4CF75400272433 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		70D42E0B2E6075F3002AC32C /* AnyRealmValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */; };
 		8E6389BC2A2724D000306FA4 /* TPStreamPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */; };
 		8E6389C42A27277D00306FA4 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389C32A27277D00306FA4 /* ExampleApp.swift */; };
 		8E6389C62A27277D00306FA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389C52A27277D00306FA4 /* ContentView.swift */; };
@@ -200,6 +201,7 @@
 		03CE75012A7A337B00B84304 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveIndicatorView.swift; sourceTree = "<group>"; };
 		03D7F4272C22C4F900DF3597 /* PlaybackSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackSpeed.swift; sourceTree = "<group>"; };
+		70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerView.swift; sourceTree = "<group>"; };
 		8E6389C12A27277D00306FA4 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E6389C32A27277D00306FA4 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 		0321F3252A2E0D0300E08AEE /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */,
 				0321F3262A2E0D1800E08AEE /* AVPlayer.swift */,
 				03CE75012A7A337B00B84304 /* UIView.swift */,
 				037F3BBE2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift */,
@@ -807,6 +810,7 @@
 				D92E48D62CAFCD2400B1FAC3 /* OfflineAsset.swift in Sources */,
 				D960A8FB2CEDEE7C003B0B04 /* M3U8Parser.swift in Sources */,
 				03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */,
+				70D42E0B2E6075F3002AC32C /* AnyRealmValue.swift in Sources */,
 				03D7F4252C21C64D00DF3597 /* LiveIndicatorView.swift in Sources */,
 				0321F3272A2E0D1800E08AEE /* AVPlayer.swift in Sources */,
 				D9A2F2AE2CE2102E0052802D /* ContentKeyDelegate+Persistable.swift in Sources */,


### PR DESCRIPTION
- Download items in mobile platforms support attaching custom metadata, which allows user to store additional context with offline assets.
- iOS lacked this support, and this change adds it to ensure consistency and a unified cross-platform experience.