### PR TITLE
fix: Handle one-time access token expiry during download

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -17,6 +17,7 @@ public final class TPStreamsDownloadManager {
     private var contentKeySession: AVContentKeySession!
     private var contentKeyDelegate: ContentKeyDelegate!
     private let contentKeyDelegateQueue = DispatchQueue(label: "com.tpstreams.iOSPlayerSDK.ContentKeyDelegateQueueOffline")
+    public var onAccessTokenExpired: ((String, @escaping (String?) -> Void) -> Void)?
 
     private init() {
         let backgroundConfiguration = URLSessionConfiguration.background(withIdentifier: "com.tpstreams.downloadSession")
@@ -224,7 +225,14 @@ public final class TPStreamsDownloadManager {
             .filter { $0.status != Status.deleted.rawValue }
             .map { $0.asOfflineAsset() }
     }
-
+    
+    public func notifyAccessTokenExpired(assetID: String, completion: @escaping (String?) -> Void) {
+        if let handler = onAccessTokenExpired {
+            handler(assetID, completion)
+        } else {
+            completion(nil)
+        }
+    }
 }
 
 internal class AssetDownloadDelegate: NSObject, AVAssetDownloadDelegate {

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -124,7 +124,38 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     
     func requestCKC(_ spcData: Data, _ completion: @escaping(Data?, Error?) -> Void) {
         guard let assetID = assetID else { return }
-        TPStreamsSDK.provider.API.getDRMLicense(assetID, accessToken, spcData, contentID!, forOfflinePlayback, completion)
+        TPStreamsSDK.provider.API.getDRMLicense(
+            assetID, 
+            accessToken, 
+            spcData, 
+            contentID!, 
+            forOfflinePlayback
+        ) { [weak self] data, error in
+            guard let self = self else { return }
+            
+            if let error = error as? TPStreamPlayerError,
+               error == .unauthorizedAccess && forOfflinePlayback{
+                print("TPStreamsSDK: Access token expired found for assetID: \(assetID)")
+                TPStreamsDownloadManager.shared.notifyAccessTokenExpired(assetID: assetID) { newToken in 
+                    if let newToken = newToken {
+                        self.accessToken = newToken
+                        TPStreamsSDK.provider.API.getDRMLicense(
+                            assetID, 
+                            newToken, 
+                            spcData, 
+                            self.contentID!, 
+                            self.forOfflinePlayback
+                        ) { data, error in
+                            completion(data, error)
+                        }
+                    } else {
+                        completion(nil, error)
+                    }
+                }
+                return
+            }
+            completion(data, error)
+        }
     }
     
     func setAssetDetails(_ assetID: String?, _ accessToken: String?, _ forOfflinePlayback: Bool = false) {

--- a/Source/Network/BaseAPI.swift
+++ b/Source/Network/BaseAPI.swift
@@ -56,11 +56,17 @@ class BaseAPI {
             switch response.result {
             case .success(let data):
                 if response.response?.statusCode == 200 {
+                    print("TPStreamsSDK: License key fetched successfully")
                     completion(data, nil)
+                } else if response.response?.statusCode == 401 {
+                    print("TPStreamsSDK: Unauthorized access")
+                    completion(nil, TPStreamPlayerError.unauthorizedAccess)
                 } else {
+                    print("TPStreamsSDK: Failed to fetch license key with status code: \(response.response?.statusCode ?? 0)")
                     completion(nil, TPStreamPlayerError.failedToFetchLicenseKey)
                 }
             case .failure(_):
+                print("TPStreamsSDK: Failed to fetch license key")
                 completion(nil, TPStreamPlayerError.failedToFetchLicenseKey)
             }
             


### PR DESCRIPTION
- Previously, offline DRM license downloads failed because one-time access tokens were already consumed during playback, causing unexpected behavior in offline media playback. 
- Added `onAccessTokenExpiry` callback to refresh access tokens when they expire during downloads.