### PR TITLE
fix: Remove leftover DRM keys when deleting offline assets

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -163,7 +163,7 @@ public final class TPStreamsDownloadManager {
         
         if let task = assetDownloadDelegate.activeDownloadsMap.first(where: { $0.value == localOfflineAsset })?.key {
             task.cancel()
-            self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
+            self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!, localOfflineAsset: localOfflineAsset) { success, error in
                 if success {
                     LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
                 } else {
@@ -182,7 +182,7 @@ public final class TPStreamsDownloadManager {
                 return
             }
             
-            self.deleteDownloadedFile(downloadedFileURL) { success, error in
+            self.deleteDownloadedFile(downloadedFileURL, localOfflineAsset: localOfflineAsset) { success, error in
                 if success {
                     LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
                 } else {
@@ -200,7 +200,7 @@ public final class TPStreamsDownloadManager {
         LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["status": Status.deleted.rawValue])
         tpStreamsDownloadDelegate?.onDelete(assetId: localOfflineAsset.assetId)
         
-        self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!) { success, error in
+        self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!, localOfflineAsset: localOfflineAsset) { success, error in
             if success {
                 LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
             } else {
@@ -209,10 +209,17 @@ public final class TPStreamsDownloadManager {
         }
     }
     
-    private func deleteDownloadedFile(_ downloadedFileURL: URL, completion: @escaping (Bool, Error?) -> Void) {
+    private func deleteDownloadedFile(_ downloadedFileURL: URL, localOfflineAsset: LocalOfflineAsset, completion: @escaping (Bool, Error?) -> Void) {
         DispatchQueue.global(qos: .background).async {
             do {
                 try FileManager.default.removeItem(at: downloadedFileURL)
+                
+                DispatchQueue.main.async {
+                    if let drmContentId = localOfflineAsset.drmContentId {
+                        self.contentKeyDelegate.cleanupPersistentContentKey(for: drmContentId)
+                    }
+                }
+                
                 DispatchQueue.main.async {
                     completion(true, nil)
                 }

--- a/Source/Managers/ContentKeyDelegate+Persistable.swift
+++ b/Source/Managers/ContentKeyDelegate+Persistable.swift
@@ -80,6 +80,12 @@ extension ContentKeyDelegate {
         
         try contentKey.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
     }
+
+    func cleanupPersistentContentKey(for contentID: String) {
+        if let keyURL = getPersistentContentKeyURL() {
+            try? FileManager.default.removeItem(at: keyURL)
+        }
+    }
     
     func getPersistentContentKeyURL() -> URL?{
         guard let contentID = self.contentID else { return nil }


### PR DESCRIPTION
- Offline assets with DRM content were leaving persistent keys behind when deleted, causing unnecessary storage usage and potential conflicts.
- This commit adds proper cleanup of these keys when an offline asset is deleted.