### PR TITLE
feat: Add DRM license expiry support for offline content

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -238,6 +238,13 @@ public final class TPStreamsDownloadManager {
             .map { $0.asOfflineAsset() }
     }
 
+    public func updateOfflineLicenseExpiry(_ assetID: String, expiryDate: Date?) {
+        DispatchQueue.main.async {
+            let updateData: [String: Any] = ["licenseExpiryDate": expiryDate ?? NSNull()]
+            LocalOfflineAsset.manager.update(id: assetID, with: updateData)
+        }
+    }
+
     private func requestPersistentKeyWithNewAccessToken() {
         guard let assetId = contentKeyDelegate.assetID else { return }
         guard let delegate = tpStreamsDownloadDelegate else { return }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -52,14 +52,14 @@ public final class TPStreamsDownloadManager {
         return false
     }
 
-    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: [String: Any]? = nil) throws {
+    internal func startDownload(asset: Asset, accessToken: String?, videoQuality: VideoQuality, metadata: [String: Any]? = nil, offlineLicenseDurationSeconds: Double? = nil) throws {
         #if targetEnvironment(simulator)
             if (asset.video?.drmEncrypted == true){
                 print("Downloading DRM content is not supported in simulator")
                 throw NSError(domain: "TPStreamsSDK", code: -1, userInfo: [NSLocalizedDescriptionKey: "DRM content downloading is not supported in simulator"])
             }
         #else
-            contentKeyDelegate.setAssetDetails(asset.id, accessToken, true)
+            contentKeyDelegate.setAssetDetails(asset.id, accessToken, true, offlineLicenseDurationSeconds)
         #endif
 
         if LocalOfflineAsset.manager.exists(id: asset.id) {

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -15,6 +15,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     public var onError: ((Error) -> Void)?
     var requestingPersistentKey = false
     var forOfflinePlayback = false
+    var licenseDurationSeconds: Double? = nil
     
     enum ProgramError: Error {
         case missingApplicationCertificate
@@ -124,12 +125,13 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     
     func requestCKC(_ spcData: Data, _ completion: @escaping(Data?, Error?) -> Void) {
         guard let assetID = assetID else { return }
-        TPStreamsSDK.provider.API.getDRMLicense(assetID, accessToken, spcData, contentID!, forOfflinePlayback, completion)
+        TPStreamsSDK.provider.API.getDRMLicense(assetID, accessToken, spcData, contentID!, forOfflinePlayback, forOfflinePlayback ? licenseDurationSeconds : nil, completion)
     }
     
-    func setAssetDetails(_ assetID: String?, _ accessToken: String?, _ forOfflinePlayback: Bool = false) {
+    func setAssetDetails(_ assetID: String?, _ accessToken: String?, _ forOfflinePlayback: Bool = false, _ licenseDurationSeconds: Double? = nil) {
         self.assetID = assetID
         self.accessToken = accessToken
         self.forOfflinePlayback = forOfflinePlayback
+        self.licenseDurationSeconds = licenseDurationSeconds
     }
 }

--- a/Source/Network/BaseAPI.swift
+++ b/Source/Network/BaseAPI.swift
@@ -35,9 +35,18 @@ class BaseAPI {
             }
     }
     
-    static func getDRMLicense(_ assetID: String, _ accessToken: String?, _ spcData: Data, _ contentID: String, _ forOfflinePlayback: Bool, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
-        let url = URL(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? "", (forOfflinePlayback == true ? "true" : "false")))!
-        
+    static func getDRMLicense(_ assetID: String, _ accessToken: String?, _ spcData: Data, _ contentID: String, _ forOfflinePlayback: Bool, _ licenseDurationSeconds: Double? = nil, _ completion:@escaping(Data?, Error?) -> Void) -> Void {
+        var components = URLComponents(string: String(format: DRM_LICENSE_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? "", (forOfflinePlayback == true ? "true" : "false")))!
+
+        if forOfflinePlayback {
+            if let licenseDuration = licenseDurationSeconds, licenseDuration > 0 {
+                var queryItems = components.queryItems ?? []
+                queryItems.append(URLQueryItem(name: "license_duration_seconds", value: String(Int(licenseDuration))))
+                queryItems.append(URLQueryItem(name: "rental_duration_seconds", value: String(Int(licenseDuration))))
+                components.queryItems = queryItems
+            }
+        }
+        let url = components.url!
         let parameters = [
             "spc": spcData.base64EncodedString(),
             "assetId" : contentID

--- a/Source/TPStreamPlayerConfiguration.swift
+++ b/Source/TPStreamPlayerConfiguration.swift
@@ -15,6 +15,7 @@ public struct TPStreamPlayerConfiguration {
     public var progressBarThumbColor: UIColor = .red
     public var showDownloadOption: Bool = false
     public var downloadMetadata: [String: Any]? = nil
+    public var licenseDurationSeconds: Double? = nil
 }
 
 
@@ -52,6 +53,11 @@ public class TPStreamPlayerConfigurationBuilder {
     
     public func setDownloadMetadata(_ metadata: [String: Any]?) -> Self {
         configuration.downloadMetadata = metadata
+        return self
+    }
+    
+    public func setLicenseDurationSeconds(_ seconds: Double?) -> Self {
+        configuration.licenseDurationSeconds = seconds
         return self
     }
     

--- a/Source/Views/SwiftUI/PlayerSettingsButton.swift
+++ b/Source/Views/SwiftUI/PlayerSettingsButton.swift
@@ -132,7 +132,8 @@ struct PlayerSettingsButton: View {
                             asset: player.asset!, 
                             accessToken: player.player.accessToken, 
                             videoQuality: downloadQuality,
-                            metadata: playerConfig.downloadMetadata
+                            metadata: playerConfig.downloadMetadata,
+                            offlineLicenseDurationSeconds: playerConfig.licenseDurationSeconds
                         )
                     } catch {
                         print("Error downloading video: \(error)")

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -249,7 +249,8 @@ class PlayerControlsUIView: UIView {
                     asset: self.player.asset!, 
                     accessToken: self.player.player.accessToken, 
                     videoQuality: quality,
-                    metadata: self.playerConfig.downloadMetadata
+                    metadata: self.playerConfig.downloadMetadata,
+                    offlineLicenseDurationSeconds: self.playerConfig.licenseDurationSeconds
                 )
             } catch {
                 print("Error downloading video: \(error)")


### PR DESCRIPTION
- Add support for specifying DRM license expiry for offline content, allowing users to set an expiration time for offline assets. 
- This ensures that content becomes inaccessible after the defined period, helping enforce proper access control.