### PR TITLE
feat: Add license expiry date field for offline DRM license tracking

### DIFF
--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -25,6 +25,7 @@ class LocalOfflineAsset: Object {
     @Persisted var folderTree: String = ""
     @Persisted var drmContentId: String? = nil
     @Persisted var metadataMap = Map<String, AnyRealmValue>()
+    @Persisted var licenseExpiryDate: Date? = nil
     
     static var manager = ObjectManager<LocalOfflineAsset>()
     

--- a/Source/Database/Models/OfflineAssetEntity.swift
+++ b/Source/Database/Models/OfflineAssetEntity.swift
@@ -126,4 +126,10 @@ extension LocalOfflineAsset {
         }
         return nil
     }
+
+    func isOfflineLicenseExpired() -> Bool {
+        guard let expiryDate = self.licenseExpiryDate else { return true }
+        let remainingTime = expiryDate.timeIntervalSince(Date())
+        return remainingTime <= 0
+    }
 }

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -68,9 +68,9 @@ public class TPStreamsSDK {
     
     private static func initializeDatabase() {
         var config = Realm.Configuration(
-            schemaVersion: 3,
+            schemaVersion: 4,
             migrationBlock: { migration, oldSchemaVersion in
-                if oldSchemaVersion < 3 {
+                if oldSchemaVersion < 4 {
                         // No manual migration needed.
                         // Realm automatically handles newly added optional properties.
                 }


### PR DESCRIPTION
- DRM licenses for offline content have expiration dates that need to be tracked to ensure valid playback and enable license renewal workflows. Without storing the expiry date, the SDK cannot proactively manage license validity or provide users with timely renewal notifications.

- This change enables the SDK to track when offline DRM licenses expire, allowing for better user experience through proactive license management and preventing playback failures due to expired licenses.