### PR TITLE
fix: Prevent incomplete DRM downloads on license failure

### DIFF
--- a/Source/Database/Models/OfflineAsset.swift
+++ b/Source/Database/Models/OfflineAsset.swift
@@ -35,6 +35,8 @@ public struct OfflineAsset: Hashable {
 
 public enum Status: String {
     case notStarted = "notStarted"
+    case acquiringLicense = "acquiringLicense"
+    case licenseAcquisitionFailed = "licenseAcquisitionFailed"
     case inProgress = "inProgress"
     case paused = "paused"
     case finished = "finished"

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -284,12 +284,13 @@ public final class TPStreamsDownloadManager {
     private func requestPersistentKeyWithNewAccessToken() {
         guard let assetId = contentKeyDelegate.assetID else { return }
         guard let delegate = tpStreamsDownloadDelegate else { return }
+        guard let licenseDurationSeconds = contentKeyDelegate.licenseDurationSeconds else { return }
         
         delegate.onRequestNewAccessToken(assetId: assetId) { [weak self] newToken in
             guard let self = self else { return }
             
             if let newToken = newToken {
-                self.contentKeyDelegate.setAssetDetails(assetId, newToken, true)
+                self.contentKeyDelegate.setAssetDetails(assetId, newToken, true, licenseDurationSeconds)
                 DispatchQueue.main.async {
                     self.requestPersistentKey(assetId)
                 }

--- a/Source/Managers/ContentKeyDelegate+Persistable.swift
+++ b/Source/Managers/ContentKeyDelegate+Persistable.swift
@@ -82,7 +82,7 @@ extension ContentKeyDelegate {
                 keyRequest.processContentKeyResponse(keyResponse)
                 
                 if self.requestingPersistentKey {
-                    self.onSuccess?()
+                    self.onDRMLicenseAcquired?()
                 }
             } catch {
                 print(error)

--- a/Source/Managers/ContentKeyDelegate+Persistable.swift
+++ b/Source/Managers/ContentKeyDelegate+Persistable.swift
@@ -80,6 +80,10 @@ extension ContentKeyDelegate {
                 
                 let keyResponse = AVContentKeyResponse(fairPlayStreamingKeyResponseData: ckcData)
                 keyRequest.processContentKeyResponse(keyResponse)
+                
+                if self.requestingPersistentKey {
+                    self.onSuccess?()
+                }
             } catch {
                 print(error)
             }

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -13,7 +13,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     var assetID: String?
     var accessToken: String?
     public var onError: ((Error) -> Void)?
-    public var onSuccess: (() -> Void)?
+    public var onDRMLicenseAcquired: (() -> Void)?
     public var onRequestOfflineLicenseRenewal: ((String, @escaping (String?, Double?) -> Void) -> Void)?
     var requestingPersistentKey = false
     var forOfflinePlayback = false

--- a/Source/Managers/ContentKeyDelegate.swift
+++ b/Source/Managers/ContentKeyDelegate.swift
@@ -13,6 +13,7 @@ class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
     var assetID: String?
     var accessToken: String?
     public var onError: ((Error) -> Void)?
+    public var onSuccess: (() -> Void)?
     public var onRequestOfflineLicenseRenewal: ((String, @escaping (String?, Double?) -> Void) -> Void)?
     var requestingPersistentKey = false
     var forOfflinePlayback = false


### PR DESCRIPTION
- DRM downloads were starting before license acquisition completed, causing incomplete downloads with error 5002 when license requests failed. 
- Downloads now wait for successful license acquisition before starting, preventing incomplete downloads. If license acquisition fails, the download remains in notStarted state and the download task is never created.