### PR TITLE
feat: Add support for DRM-protected live streams on iOS

### DIFF
--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -30,4 +30,8 @@ struct Asset {
     var keyIdentifier: String {
         return id
     }
+
+    var isDrmEncrypted: Bool {
+        return video?.drmEncrypted == true || liveStream?.enableDRM == true
+    }
 }

--- a/Source/Network/Models/LiveStream.swift
+++ b/Source/Network/Models/LiveStream.swift
@@ -13,6 +13,7 @@ struct LiveStream{
     let transcodeRecordedVideo: Bool
     let chatEmbedUrl: String
     let noticeMessage: String?
+    let enableDRM: Bool
     
     var isStreaming: Bool {
         return status == "Streaming" || status == "Running"

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -55,7 +55,8 @@ class StreamsAPIParser: APIParser {
             return nil
         }
         let noticeMessage = liveStreamDict["notice_message"] as? String
+        let enableDRM = liveStreamDict["enable_drm"] as? Bool ?? false
    
-        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage)
+        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage, enableDRM: enableDRM)
     }
 }

--- a/Source/Network/Parsers/TestpressAPIParser.swift
+++ b/Source/Network/Parsers/TestpressAPIParser.swift
@@ -60,7 +60,8 @@ class TestpressAPIParser: APIParser {
         
         let noticeMessage = liveStreamDict["notice_message"] as? String
         let transcodeRecordedVideo = liveStreamDict["show_recorded_video"] as? Bool ?? false
+        let enableDRM = false
         
-        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage)
+        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage, enableDRM: enableDRM)
     }
 }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -98,7 +98,7 @@ public class TPAVPlayer: AVPlayer {
             }
 
             #if targetEnvironment(simulator)
-            if asset?.drmEncrypted == true {
+            if asset?.isDrmEncrypted == true {
                 self.processInitializationFailure(TPStreamPlayerError.drmSimulatorError)
                 return
             }

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -98,7 +98,7 @@ public class TPAVPlayer: AVPlayer {
             }
 
             #if targetEnvironment(simulator)
-            if asset?.video?.drmEncrypted == true {
+            if asset?.drmEncrypted == true {
                 self.processInitializationFailure(TPStreamPlayerError.drmSimulatorError)
                 return
             }
@@ -142,7 +142,7 @@ public class TPAVPlayer: AVPlayer {
         avURLAsset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
         self.setPlayerItem(avURLAsset)
         
-        if asset.video?.drmEncrypted == true {
+        if asset.isDrmEncrypted == true {
             self.setupDRM(avURLAsset)
         }
         self.populateAvailableVideoQualities(url)


### PR DESCRIPTION
- DRM-enabled live streams were not playable in the iOS SDK
- This caused playback failures for secured live content
- Added support to handle DRM for live streams