### PR TITLE
fix: Relax Sentry dependency constraint

### DIFF
--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/testpress/iOSPlayerSDK.git", :tag => spec.version }
   spec.source_files  = "Source/**/*.{swift,plist}"
   spec.exclude_files = "Classes/Exclude"
-  spec.dependency 'Sentry', '~> 8.50.0'
+  spec.dependency 'Sentry', '>= 8.50', '< 10'
+
   spec.dependency 'Alamofire', '~> 5.9.0'
   spec.dependency 'M3U8Kit', '~> 1.2.0'
   spec.dependency 'ReachabilitySwift', '~> 5.2.2'


### PR DESCRIPTION
- Updated the Sentry CocoaPods dependency from `~> 8.50.0` to `>= 8.50, < 10`
- Improved compatibility with consumer app dependency versions
- Required for the React Native client Namaste Dev using Sentry v9.13.0