### PR TITLE
feat: Encapsulate player controls inside a dedicated container view

### DIFF
--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -54,7 +54,7 @@ public class TPStreamPlayerViewController: UIViewController {
         view.player = TPStreamPlayer(player: self.player!)
         view.playerConfig = config
         view.frame = view.bounds
-        view.isHidden = true
+        view.controlsContainer.isHidden = true
         view.fullScreenToggleDelegate = self
         view.controlsDelegate = self
         view.parentViewController = self
@@ -157,13 +157,13 @@ public class TPStreamPlayerViewController: UIViewController {
     }
     
     @objc private func toggleControlsVisibility() {
-        controlsView.isHidden = !controlsView.isHidden
+        controlsView.controlsContainer.isHidden = !controlsView.controlsContainer.isHidden
         
-        // Hide controls view after 10 seconds
-        if !controlsView.isHidden {
+        // Hide controls container after 10 seconds
+        if !controlsView.controlsContainer.isHidden {
             controlsVisibilityTimer?.invalidate()
             controlsVisibilityTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { [weak self] _ in
-                self?.controlsView.isHidden = true
+                self?.controlsView.controlsContainer.isHidden = true
             }
         }
     }

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -26,13 +26,13 @@ public class TPStreamPlayerViewController: UIViewController {
     public var autoFullScreenOnRotate = true
     public var config = TPStreamPlayerConfiguration(){
         didSet {
-            controlsView.playerConfig = config
+            overlayView.playerConfig = config
         }
     }
     private var controlsVisibilityTimer: Timer?
     public private(set) var isFullScreen: Bool = false {
         didSet {
-            controlsView.isFullScreen = isFullScreen
+            overlayView.isFullScreen = isFullScreen
             setNeedsStatusBarAppearanceUpdate()
         }
     }
@@ -47,18 +47,18 @@ public class TPStreamPlayerViewController: UIViewController {
         return view
     }()
     
-    private lazy var controlsView: PlayerControlsUIView = {
-        guard let view = bundle.loadNibNamed("PlayerControls", owner: nil, options: nil)?.first as? PlayerControlsUIView else {
-            fatalError("Could not load PlayerControls view from nib.")
+    private lazy var overlayView: PlayerOverlay = {
+        guard let overlay = bundle.loadNibNamed("PlayerOverlay", owner: nil, options: nil)?.first as? PlayerOverlay else {
+            fatalError("Could not load PlayerOverlay view from nib.")
         }
-        view.player = TPStreamPlayer(player: self.player!)
-        view.playerConfig = config
-        view.frame = view.bounds
-        view.controlsContainer.isHidden = true
-        view.fullScreenToggleDelegate = self
-        view.controlsDelegate = self
-        view.parentViewController = self
-        return view
+        overlay.player = TPStreamPlayer(player: self.player!)
+        overlay.playerConfig = config
+        overlay.frame = overlay.bounds
+        overlay.controls.isHidden = true
+        overlay.fullScreenToggleDelegate = self
+        overlay.controlsDelegate = self
+        overlay.parentViewController = self
+        return overlay
     }()
     
     private lazy var noticeView: UIView = {
@@ -73,9 +73,9 @@ public class TPStreamPlayerViewController: UIViewController {
         let view = UIView(frame: view.bounds)
         view.backgroundColor = .black
         view.addSubview(videoView)
-        view.addSubview(controlsView)
+        view.addSubview(overlayView)
         view.addSubview(noticeView)
-        view.bringSubviewToFront(controlsView)
+        view.bringSubviewToFront(overlayView)
         return view
     }()
     
@@ -106,7 +106,7 @@ public class TPStreamPlayerViewController: UIViewController {
         super.viewDidLayoutSubviews()
         containerView.frame = containerView.superview!.bounds
         videoView.frame = containerView.bounds
-        controlsView.frame = containerView.bounds
+        overlayView.frame = containerView.bounds
         noticeView.frame = containerView.bounds
         noticeMessageLabel.frame = noticeView.bounds
     }
@@ -157,13 +157,13 @@ public class TPStreamPlayerViewController: UIViewController {
     }
     
     @objc private func toggleControlsVisibility() {
-        controlsView.controlsContainer.isHidden = !controlsView.controlsContainer.isHidden
+        overlayView.controls.isHidden = !overlayView.controls.isHidden
         
         // Hide controls container after 10 seconds
-        if !controlsView.controlsContainer.isHidden {
+        if !overlayView.controls.isHidden {
             controlsVisibilityTimer?.invalidate()
             controlsVisibilityTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { [weak self] _ in
-                self?.controlsView.controlsContainer.isHidden = true
+                self?.overlayView.controls.isHidden = true
             }
         }
     }
@@ -238,7 +238,7 @@ extension TPStreamPlayerViewController: FullScreenToggleDelegate, PlayerControls
     }
 
     func didTapReplay() {
-        controlsView.player?.replay()
+        overlayView.player?.replay()
         delegate?.didTapReplay()
     }
 }

--- a/Source/TPStreamsSDK.swift
+++ b/Source/TPStreamsSDK.swift
@@ -17,7 +17,7 @@ import RealmSwift
     let appBundle = Bundle(for: TPStreamsSDK.self)
     let bundle: Bundle = {
         let candidates = [appBundle, Bundle.main]
-        guard let foundBundle = candidates.first(where: { $0.path(forResource: "PlayerControls", ofType: "nib") != nil }) else {
+        guard let foundBundle = candidates.first(where: { $0.path(forResource: "PlayerOverlay", ofType: "nib") != nil }) else {
             fatalError("TPStreamsSDK: Could not locate UI resources. Please ensure the SDK is integrated correctly.")
         }
         return foundBundle

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -24,6 +24,7 @@ class PlayerControlsUIView: UIView {
     @IBOutlet weak var forwardSeekNoticeLabel: UILabel!
     
     @IBOutlet weak var liveIndicatorContainer: UIView!
+    @IBOutlet weak var controlsContainer: UIView!
 
     private lazy var liveIndicatorView: LiveIndicatorView = {
         let indicatorView = LiveIndicatorView(frame: liveIndicatorContainer.bounds)

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -26,6 +26,13 @@ class PlayerControlsUIView: UIView {
     @IBOutlet weak var liveIndicatorContainer: UIView!
     @IBOutlet weak var controlsContainer: UIView!
 
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        guard let controlsContainer = controlsContainer, !controlsContainer.isHidden else {
+            return false
+        }
+        return controlsContainer.frame.contains(point)
+    }
+
     private lazy var liveIndicatorView: LiveIndicatorView = {
         let indicatorView = LiveIndicatorView(frame: liveIndicatorContainer.bounds)
         return indicatorView

--- a/Source/Views/UIKit/PlayerOverlay.swift
+++ b/Source/Views/UIKit/PlayerOverlay.swift
@@ -10,7 +10,7 @@ import UIKit
 
 let ACTION_SHEET_PREFERRED_STYLE: UIAlertController.Style  = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
 
-class PlayerControlsUIView: UIView {
+class PlayerOverlay: UIView {
     @IBOutlet weak var playPauseButton: UIButton!
     @IBOutlet weak var currentTimelabel: UILabel!
     @IBOutlet weak var videoDurationLabel: UILabel!
@@ -24,13 +24,13 @@ class PlayerControlsUIView: UIView {
     @IBOutlet weak var forwardSeekNoticeLabel: UILabel!
     
     @IBOutlet weak var liveIndicatorContainer: UIView!
-    @IBOutlet weak var controlsContainer: UIView!
+    @IBOutlet weak var controls: UIView!
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        guard let controlsContainer = controlsContainer, !controlsContainer.isHidden else {
+        guard let controls = controls, !controls.isHidden else {
             return false
         }
-        return controlsContainer.frame.contains(point)
+        return controls.frame.contains(point)
     }
 
     private lazy var liveIndicatorView: LiveIndicatorView = {

--- a/Source/Views/UIKit/Xib/PlayerControls.xib
+++ b/Source/Views/UIKit/Xib/PlayerControls.xib
@@ -1,157 +1,162 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view hidden="YES" contentMode="scaleToFill" id="Pdx-qm-hxi" customClass="PlayerControlsUIView" customModule="TPStreamsSDK">
+        <view contentMode="scaleToFill" id="Pdx-qm-hxi" customClass="PlayerControlsUIView" customModule="TPStreamsSDK">
             <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rWY-7h-2Dd">
-                    <rect key="frame" x="308.5" y="162.5" width="50" height="50"/>
-                    <accessibility key="accessibilityConfiguration">
-                        <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
-                    </accessibility>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="50" id="ETk-Sk-Mal"/>
-                        <constraint firstAttribute="width" constant="50" id="uMK-gP-Wjv"/>
-                    </constraints>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" title="Button" image="play"/>
-                    <connections>
-                        <action selector="playOrPauseButton:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="zZ1-fC-D6w"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z2i-lj-k69">
-                    <rect key="frame" x="448.5" y="167.5" width="40" height="40"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="40" id="4Q0-dz-w8U"/>
-                        <constraint firstAttribute="height" constant="40" id="be7-27-vE0"/>
-                    </constraints>
-                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" title="Button" image="forward">
-                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </state>
-                    <connections>
-                        <action selector="forward:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="CxU-JN-ED0"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HpI-yc-TvP">
-                    <rect key="frame" x="178.5" y="167.5" width="40" height="40"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="40" id="2qV-lx-kRz"/>
-                        <constraint firstAttribute="width" constant="40" id="P8S-69-Jm3"/>
-                    </constraints>
-                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" image="rewind">
-                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </state>
-                    <connections>
-                        <action selector="rewind:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="wdS-LN-haB"/>
-                    </connections>
-                </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rJo-p9-gc7">
-                    <rect key="frame" x="18" y="338" width="46.5" height="22"/>
-                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAe-VC-JKX">
-                    <rect key="frame" x="80" y="338" width="46.5" height="22"/>
-                    <accessibility key="accessibilityConfiguration">
-                        <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                    </accessibility>
-                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                    <color key="textColor" red="0.90496091437093995" green="0.90496091437093995" blue="0.90496091437093995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ad7-vR-GCz">
-                    <rect key="frame" x="585" y="340" width="20" height="20"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="20" id="OJO-Sb-Lwh"/>
-                        <constraint firstAttribute="width" constant="20" id="q4h-Zj-29l"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" title="" image="settings"/>
-                    <connections>
-                        <action selector="showOptionsMenu:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="ui5-FT-Sea"/>
-                    </connections>
-                </button>
-                <activityIndicatorView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="FGD-AH-xjx">
-                    <rect key="frame" x="315" y="170" width="37" height="37"/>
-                </activityIndicatorView>
-                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5BF-uG-JOj">
-                    <rect key="frame" x="633" y="340" width="22" height="22"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="JIr-e2-U6x"/>
-                        <constraint firstAttribute="width" constant="22" id="qKx-2Z-8rO"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" image="maximize"/>
-                    <connections>
-                        <action selector="toggleFullScreen:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="42m-nt-Uz0"/>
-                    </connections>
-                </button>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1u3-pU-CDM" customClass="ProgressBar" customModule="TPStreamsSDK">
-                    <rect key="frame" x="12" y="314" width="645" height="18"/>
-                    <color key="backgroundColor" red="0.37098549014514259" green="0.37098549014514259" blue="0.37098549014514259" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="18" id="JLq-Sd-gLN"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ar-ud-LQI">
-                    <rect key="frame" x="69" y="339" width="7" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" -10s" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e7F-Lb-uzC">
-                    <rect key="frame" x="129.5" y="177" width="48" height="21.5"/>
-                    <accessibility key="accessibilityConfiguration">
-                        <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                    </accessibility>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="48" id="N5n-vc-TYR"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" +10s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbY-Vi-98f">
-                    <rect key="frame" x="489.5" y="176.5" width="48" height="22"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="48" id="Nnw-CQ-ejD"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JwQ-W5-Iai">
-                    <rect key="frame" x="79" y="338" width="54" height="22"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="PCX-lH-htb"/>
-                        <constraint firstAttribute="width" constant="54" id="poE-gJ-psM"/>
-                    </constraints>
+                <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CCC-cc-ccc">
+                    <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rWY-7h-2Dd">
+                            <rect key="frame" x="308.5" y="162.5" width="50" height="50"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
+                            </accessibility>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="50" id="ETk-Sk-Mal"/>
+                                <constraint firstAttribute="width" constant="50" id="uMK-gP-Wjv"/>
+                            </constraints>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Button" image="play"/>
+                            <connections>
+                                <action selector="playOrPauseButton:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="zZ1-fC-D6w"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z2i-lj-k69">
+                            <rect key="frame" x="448.5" y="167.5" width="40" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="4Q0-dz-w8U"/>
+                                <constraint firstAttribute="height" constant="40" id="be7-27-vE0"/>
+                            </constraints>
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Button" image="forward">
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                            <connections>
+                                <action selector="forward:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="CxU-JN-ED0"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HpI-yc-TvP">
+                            <rect key="frame" x="178.5" y="167.5" width="40" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="40" id="2qV-lx-kRz"/>
+                                <constraint firstAttribute="width" constant="40" id="P8S-69-Jm3"/>
+                            </constraints>
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="rewind">
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                            <connections>
+                                <action selector="rewind:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="wdS-LN-haB"/>
+                            </connections>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rJo-p9-gc7">
+                            <rect key="frame" x="18" y="338" width="46.5" height="22"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAe-VC-JKX">
+                            <rect key="frame" x="80" y="338" width="46.5" height="22"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                            </accessibility>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                            <color key="textColor" red="0.90496091437093995" green="0.90496091437093995" blue="0.90496091437093995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ad7-vR-GCz">
+                            <rect key="frame" x="585" y="340" width="20" height="20"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="20" id="OJO-Sb-Lwh"/>
+                                <constraint firstAttribute="width" constant="20" id="q4h-Zj-29l"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="" image="settings"/>
+                            <connections>
+                                <action selector="showOptionsMenu:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="ui5-FT-Sea"/>
+                            </connections>
+                        </button>
+                        <activityIndicatorView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="FGD-AH-xjx">
+                            <rect key="frame" x="315" y="169" width="37" height="37"/>
+                        </activityIndicatorView>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5BF-uG-JOj">
+                            <rect key="frame" x="627" y="338" width="22" height="22"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="22" id="JIr-e2-U6x"/>
+                                <constraint firstAttribute="width" constant="22" id="qKx-2Z-8rO"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="maximize"/>
+                            <connections>
+                                <action selector="toggleFullScreen:" destination="Pdx-qm-hxi" eventType="touchUpInside" id="42m-nt-Uz0"/>
+                            </connections>
+                        </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1u3-pU-CDM" customClass="ProgressBar" customModule="TPStreamsSDK">
+                            <rect key="frame" x="12" y="314" width="645" height="18"/>
+                            <color key="backgroundColor" red="0.37098549014514259" green="0.37098549014514259" blue="0.37098549014514259" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="18" id="JLq-Sd-gLN"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ar-ud-LQI">
+                            <rect key="frame" x="69" y="337" width="6" height="24"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" -10s" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e7F-Lb-uzC">
+                            <rect key="frame" x="129.5" y="177" width="48" height="21.5"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                            </accessibility>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="48" id="N5n-vc-TYR"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" +10s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbY-Vi-98f">
+                            <rect key="frame" x="489.5" y="176.5" width="48" height="22"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="48" id="Nnw-CQ-ejD"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JwQ-W5-Iai">
+                            <rect key="frame" x="80" y="338" width="54" height="22"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="22" id="PCX-lH-htb"/>
+                                <constraint firstAttribute="width" constant="54" id="poE-gJ-psM"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.29605943329480228" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="w1Z-d2-tRh"/>
-            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.29605943329480228" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="hAe-VC-JKX" firstAttribute="leading" secondItem="4Ar-ud-LQI" secondAttribute="trailing" constant="5" id="0h9-JG-lEL"/>
-                <constraint firstItem="JwQ-W5-Iai" firstAttribute="leading" secondItem="4Ar-ud-LQI" secondAttribute="trailing" constant="4" id="0xq-2L-asp"/>
                 <constraint firstItem="z2i-lj-k69" firstAttribute="leading" secondItem="rWY-7h-2Dd" secondAttribute="trailing" constant="90" id="7QJ-nE-LOE"/>
                 <constraint firstItem="rWY-7h-2Dd" firstAttribute="centerY" secondItem="w1Z-d2-tRh" secondAttribute="centerY" id="DTK-6K-ePo"/>
                 <constraint firstItem="1u3-pU-CDM" firstAttribute="leading" secondItem="w1Z-d2-tRh" secondAttribute="leading" constant="12" id="ELY-JA-h8j"/>
@@ -167,6 +172,10 @@
                 <constraint firstItem="rWY-7h-2Dd" firstAttribute="leading" secondItem="HpI-yc-TvP" secondAttribute="trailing" constant="90" id="XEP-Xm-Qmq"/>
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="bottom" secondItem="ad7-vR-GCz" secondAttribute="bottom" constant="15" id="ZyW-2f-u8I"/>
                 <constraint firstItem="JwQ-W5-Iai" firstAttribute="top" secondItem="1u3-pU-CDM" secondAttribute="bottom" constant="6" id="aQn-6G-6cl"/>
+                <constraint firstItem="CCC-cc-ccc" firstAttribute="bottom" secondItem="Pdx-qm-hxi" secondAttribute="bottom" id="ccc-b"/>
+                <constraint firstItem="CCC-cc-ccc" firstAttribute="leading" secondItem="Pdx-qm-hxi" secondAttribute="leading" id="ccc-l"/>
+                <constraint firstItem="CCC-cc-ccc" firstAttribute="trailing" secondItem="Pdx-qm-hxi" secondAttribute="trailing" id="ccc-r"/>
+                <constraint firstItem="CCC-cc-ccc" firstAttribute="top" secondItem="Pdx-qm-hxi" secondAttribute="top" id="ccc-t"/>
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="trailing" secondItem="5BF-uG-JOj" secondAttribute="trailing" constant="18" id="e6F-q7-5uK"/>
                 <constraint firstItem="JwQ-W5-Iai" firstAttribute="top" secondItem="hAe-VC-JKX" secondAttribute="top" id="fCh-b7-n3r"/>
                 <constraint firstItem="vbY-Vi-98f" firstAttribute="centerY" secondItem="w1Z-d2-tRh" secondAttribute="centerY" id="fsn-l3-Tfz"/>
@@ -183,6 +192,7 @@
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="bottom" secondItem="rJo-p9-gc7" secondAttribute="bottom" constant="15" id="zcD-2u-Cfj"/>
             </constraints>
             <connections>
+                <outlet property="controlsContainer" destination="CCC-cc-ccc" id="ccc-otl"/>
                 <outlet property="currentTimelabel" destination="rJo-p9-gc7" id="A5I-6V-15l"/>
                 <outlet property="forwardButton" destination="z2i-lj-k69" id="CDh-Of-PtG"/>
                 <outlet property="forwardSeekNoticeLabel" destination="vbY-Vi-98f" id="aOV-LF-VXC"/>
@@ -191,10 +201,10 @@
                 <outlet property="loadingIndicator" destination="FGD-AH-xjx" id="ptq-06-nG2"/>
                 <outlet property="playPauseButton" destination="rWY-7h-2Dd" id="kUX-RG-TOG"/>
                 <outlet property="progressBar" destination="1u3-pU-CDM" id="JtU-xe-78i"/>
-                <outlet property="rewindSeekNoticeLabel" destination="e7F-Lb-uzC" id="pk1-Z6-yA9"/>
-                <outlet property="videoDurationLabel" destination="hAe-VC-JKX" id="83w-zJ-upN"/>
                 <outlet property="rewindButton" destination="HpI-yc-TvP" id="RWd-btn-001"/>
+                <outlet property="rewindSeekNoticeLabel" destination="e7F-Lb-uzC" id="pk1-Z6-yA9"/>
                 <outlet property="settingsButton" destination="ad7-vR-GCz" id="Set-btn-001"/>
+                <outlet property="videoDurationLabel" destination="hAe-VC-JKX" id="83w-zJ-upN"/>
             </connections>
             <point key="canvasLocation" x="305.39730134932535" y="360.80000000000001"/>
         </view>

--- a/Source/Views/UIKit/Xib/PlayerOverlay.xib
+++ b/Source/Views/UIKit/Xib/PlayerOverlay.xib
@@ -10,11 +10,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="Pdx-qm-hxi" customClass="PlayerControlsUIView" customModule="TPStreamsSDK">
+        <view contentMode="scaleToFill" id="Pdx-qm-hxi" userLabel="Player Overlay View" customClass="PlayerOverlay" customModule="TPStreamsSDK">
             <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CCC-cc-ccc">
+                <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CCC-cc-ccc" userLabel="Controls">
                     <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rWY-7h-2Dd">
@@ -192,7 +192,7 @@
                 <constraint firstItem="w1Z-d2-tRh" firstAttribute="bottom" secondItem="rJo-p9-gc7" secondAttribute="bottom" constant="15" id="zcD-2u-Cfj"/>
             </constraints>
             <connections>
-                <outlet property="controlsContainer" destination="CCC-cc-ccc" id="ccc-otl"/>
+                <outlet property="controls" destination="CCC-cc-ccc" id="ccc-otl"/>
                 <outlet property="currentTimelabel" destination="rJo-p9-gc7" id="A5I-6V-15l"/>
                 <outlet property="forwardButton" destination="z2i-lj-k69" id="CDh-Of-PtG"/>
                 <outlet property="forwardSeekNoticeLabel" destination="vbY-Vi-98f" id="aOV-LF-VXC"/>

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -38,8 +38,7 @@
 		03B8FDA12A69169100DAB7AE /* TPStreamsSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDE99A42A2643B000E43EA9 /* TPStreamsSDK.framework */; };
 		03B8FDA22A69169100DAB7AE /* TPStreamsSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDE99A42A2643B000E43EA9 /* TPStreamsSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		03B8FDA92A695FED00DAB7AE /* TPStreamPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8FDA82A695FED00DAB7AE /* TPStreamPlayerViewController.swift */; };
-		03B8FDAB2A696E6D00DAB7AE /* PlayerControls.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03B8FDAA2A696E6D00DAB7AE /* PlayerControls.xib */; };
-		03B8FDAE2A69752800DAB7AE /* PlayerControlsUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8FDAD2A69752800DAB7AE /* PlayerControlsUIView.swift */; };
+		03B8FDAB2A696E6D00DAB7AE /* PlayerOverlay.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03B8FDAA2A696E6D00DAB7AE /* PlayerOverlay.xib */; };
 		03BE54182BF780D1004ED191 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 03BE54172BF780D1004ED191 /* PrivacyInfo.xcprivacy */; };
 		03BF8C522B173ED10006CBC1 /* TPStreamPlayerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF8C512B173ED10006CBC1 /* TPStreamPlayerConfiguration.swift */; };
 		03CA2D312A2F757D00532549 /* TimeIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D302A2F757D00532549 /* TimeIndicatorView.swift */; };
@@ -55,6 +54,7 @@
 		2D46EC6A2EE856BB008B559A /* M3U8Kit in Frameworks */ = {isa = PBXBuildFile; productRef = 2D46EC692EE856BB008B559A /* M3U8Kit */; };
 		2DC08F892F448BB900AABC60 /* EncryptionKeyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC08F872F448BB900AABC60 /* EncryptionKeyDelegate.swift */; };
 		2DD12A212D4CF75400272433 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		2DD25B5B2FC5E999001FD5B4 /* PlayerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD25B5A2FC5E999001FD5B4 /* PlayerOverlay.swift */; };
 		70D42E0B2E6075F3002AC32C /* AnyRealmValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */; };
 		8E6389BC2A2724D000306FA4 /* TPStreamPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */; };
 		8E6389C42A27277D00306FA4 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389C32A27277D00306FA4 /* ExampleApp.swift */; };
@@ -192,8 +192,7 @@
 		03B8FD9B2A690CAD00DAB7AE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		03B8FD9D2A690CAD00DAB7AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03B8FDA82A695FED00DAB7AE /* TPStreamPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerViewController.swift; sourceTree = "<group>"; };
-		03B8FDAA2A696E6D00DAB7AE /* PlayerControls.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PlayerControls.xib; sourceTree = "<group>"; };
-		03B8FDAD2A69752800DAB7AE /* PlayerControlsUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsUIView.swift; sourceTree = "<group>"; };
+		03B8FDAA2A696E6D00DAB7AE /* PlayerOverlay.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PlayerOverlay.xib; sourceTree = "<group>"; };
 		03BE54172BF780D1004ED191 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		03BF8C512B173ED10006CBC1 /* TPStreamPlayerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerConfiguration.swift; sourceTree = "<group>"; };
 		03CA2D302A2F757D00532549 /* TimeIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicatorView.swift; sourceTree = "<group>"; };
@@ -207,6 +206,7 @@
 		2D2BA5782F5FEB2400D53996 /* KeychainUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainUtil.swift; sourceTree = "<group>"; };
 		2D3CE81E2F5957EE0011CAB7 /* VideoQualityUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoQualityUtils.swift; sourceTree = "<group>"; };
 		2DC08F872F448BB900AABC60 /* EncryptionKeyDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyDelegate.swift; sourceTree = "<group>"; };
+		2DD25B5A2FC5E999001FD5B4 /* PlayerOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerOverlay.swift; sourceTree = "<group>"; };
 		70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerView.swift; sourceTree = "<group>"; };
 		8E6389C12A27277D00306FA4 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -344,7 +344,7 @@
 		03B8FDAC2A69749500DAB7AE /* Xib */ = {
 			isa = PBXGroup;
 			children = (
-				03B8FDAA2A696E6D00DAB7AE /* PlayerControls.xib */,
+				03B8FDAA2A696E6D00DAB7AE /* PlayerOverlay.xib */,
 			);
 			path = Xib;
 			sourceTree = "<group>";
@@ -368,8 +368,8 @@
 			children = (
 				03B8FDAC2A69749500DAB7AE /* Xib */,
 				03CC784C2A6BB6E5005E8F7E /* VideoPlayerView.swift */,
-				03B8FDAD2A69752800DAB7AE /* PlayerControlsUIView.swift */,
 				03913C472A850BF9002E7E0C /* ProgressBar.swift */,
+				2DD25B5A2FC5E999001FD5B4 /* PlayerOverlay.swift */,
 				03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */,
 			);
 			path = UIKit;
@@ -736,7 +736,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03BE54182BF780D1004ED191 /* PrivacyInfo.xcprivacy in Resources */,
-				03B8FDAB2A696E6D00DAB7AE /* PlayerControls.xib in Resources */,
+				03B8FDAB2A696E6D00DAB7AE /* PlayerOverlay.xib in Resources */,
 				03B8090E2A2DFC0F00AB3D03 /* TPStreamsSDKAssets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -784,9 +784,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				037F3BBF2B05EDD900ECEF57 /* UIInterfaceOrientationMask.swift in Sources */,
-				03B8FDAE2A69752800DAB7AE /* PlayerControlsUIView.swift in Sources */,
 				0374E3762C1B15C200CE9CF2 /* LiveStream.swift in Sources */,
 				D92E48AD2CAFBCFB00B1FAC3 /* OfflineAssetEntity.swift in Sources */,
+				2DD25B5B2FC5E999001FD5B4 /* PlayerOverlay.swift in Sources */,
 				8E6389E92A278D1D00306FA4 /* ContentKeyDelegate.swift in Sources */,
 				0374E3722C1AD2A200CE9CF2 /* TestpressAPIParser.swift in Sources */,
 				8E6389DD2A27338F00306FA4 /* AVPlayerBridge.swift in Sources */,


### PR DESCRIPTION
- Hiding the root player view also hid all overlay elements, making it difficult to support persistent UI such as subtitles or future overlay features.
- The existing view hierarchy was designed only for playback controls, and the entire root view was being hidden after inactivity or user interaction.
- Added a dedicated container view for player controls, moved all control elements into it, and updated the hide/show behavior to affect only the controls container.