### PR TITLE
fix: Ensure encryption key requests are recognized as iOS app traffic

### DIFF
--- a/Source/Managers/EncryptionKeyDelegate.swift
+++ b/Source/Managers/EncryptionKeyDelegate.swift
@@ -126,11 +126,14 @@ final class EncryptionKeyDelegate {
     
     private func makeAuthHeaders(accessToken: String?) -> HTTPHeaders {
         var headers: HTTPHeaders = []
-        if let token = TPStreamsSDK.authToken {
+ 
+        if let authToken = TPStreamsSDK.authToken, !authToken.isEmpty {
+            headers.add(name: "Authorization", value: "JWT \(authToken)")
+        } else if let token = accessToken, !token.isEmpty {
             headers.add(name: "Authorization", value: "JWT \(token)")
         }
-        if TPStreamsSDK.provider == .testpress {
-            headers.add(name: "User-Agent", value: "ios-app (iPhone)")
+        if let userAgentPrefix = TPStreamsSDK.provider.API.userAgentPrefix {
+            headers.add(name: "User-Agent", value: userAgentPrefix)
         }
         return headers
     }

--- a/Source/Managers/EncryptionKeyDelegate.swift
+++ b/Source/Managers/EncryptionKeyDelegate.swift
@@ -129,9 +129,7 @@ final class EncryptionKeyDelegate {
  
         if let authToken = TPStreamsSDK.authToken, !authToken.isEmpty {
             headers.add(name: "Authorization", value: "JWT \(authToken)")
-        } else if let token = accessToken, !token.isEmpty {
-            headers.add(name: "Authorization", value: "JWT \(token)")
-        }
+        } 
         if let userAgentPrefix = TPStreamsSDK.provider.API.userAgentPrefix {
             headers.add(name: "User-Agent", value: userAgentPrefix)
         }

--- a/Source/Managers/EncryptionKeyDelegate.swift
+++ b/Source/Managers/EncryptionKeyDelegate.swift
@@ -125,9 +125,13 @@ final class EncryptionKeyDelegate {
     }
     
     private func makeAuthHeaders(accessToken: String?) -> HTTPHeaders {
+        var headers: HTTPHeaders = []
         if let token = TPStreamsSDK.authToken {
-            return ["Authorization": "JWT \(token)"]
+            headers.add(name: "Authorization", value: "JWT \(token)")
         }
-        return [:]
+        if TPStreamsSDK.provider == .testpress {
+            headers.add(name: "User-Agent", value: "ios-app (iPhone)")
+        }
+        return headers
     }
 }


### PR DESCRIPTION
- AES encrypted videos fail to load in courses restricted to "Mobile and Desktop App Only", causing playback to stall and the player to become unresponsive.
- This happened because encryption key requests were sent without the iOS app User-Agent, causing the backend to identify them as web browser requests and deny access when web usage was disabled for the course.
- This is fixed by including the expected iOS app User-Agent in encryption key requests for Testpress providers, ensuring the backend correctly recognizes them as app-originated requests and allows video playback.