### PR TITLE
feat: Add subtitle support to UIKit player

### DIFF
--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -13,6 +13,10 @@ import CoreMedia
 public class TPStreamPlayerViewController: UIViewController {
     public var player: TPAVPlayer?{
         didSet {
+            if let obs = playerTimeObserver, let oldPlayer = oldValue {
+                oldPlayer.removeTimeObserver(obs)
+                playerTimeObserver = nil
+            }
             guard let player = player else { return }
             if isViewLoaded {
                 handlePlayerInitializationError()
@@ -122,6 +126,7 @@ public class TPStreamPlayerViewController: UIViewController {
         
         setupTapGesture()
         handlePlayerInitializationError()
+        controlsView.selectedSubtitleTrack = activeSubtitleTrack
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -17,11 +17,20 @@ public class TPStreamPlayerViewController: UIViewController {
                 handlePlayerInitializationError()
             }
             setupPlayerStatusObserver(for: player)
+            setupPlayerTimeObserver()
             showLiveStreamNotice()
             player.onError = showError
         }
     }
     private var playerStatusObervervation: NSKeyValueObservation?
+    private var playerTimeObservation: NSKeyValueObservation?
+    
+    public var activeSubtitleTrack: SubtitleTrack? {
+        didSet {
+            subtitleView.setTrack(activeSubtitleTrack)
+        }
+    }
+    
     public var delegate: TPStreamPlayerViewControllerDelegate?
     public var autoFullScreenOnRotate = true
     public var config = TPStreamPlayerConfiguration(){
@@ -61,6 +70,11 @@ public class TPStreamPlayerViewController: UIViewController {
         return view
     }()
     
+    private lazy var subtitleView: SubtitleView = {
+        let view = SubtitleView(frame: .zero)
+        return view
+    }()
+    
     private lazy var noticeView: UIView = {
         let view = UIView(frame: view.frame)
         view.isHidden = true
@@ -73,6 +87,7 @@ public class TPStreamPlayerViewController: UIViewController {
         let view = UIView(frame: view.bounds)
         view.backgroundColor = .black
         view.addSubview(videoView)
+        view.addSubview(subtitleView)
         view.addSubview(controlsView)
         view.addSubview(noticeView)
         view.bringSubviewToFront(controlsView)
@@ -106,6 +121,7 @@ public class TPStreamPlayerViewController: UIViewController {
         super.viewDidLayoutSubviews()
         containerView.frame = containerView.superview!.bounds
         videoView.frame = containerView.bounds
+        subtitleView.frame = containerView.bounds
         controlsView.frame = containerView.bounds
         noticeView.frame = containerView.bounds
         noticeMessageLabel.frame = noticeView.bounds
@@ -134,10 +150,20 @@ public class TPStreamPlayerViewController: UIViewController {
                 case "ready":
                     self.noticeView.isHidden = true
                     self.showLiveStreamNotice()
+                    if self.config.autoSelectFirstSubtitle, let tracks = self.player?.asset?.video?.tracks, let firstTrack = tracks.first {
+                        self.activeSubtitleTrack = firstTrack
+                    }
                 default:
                     break
                 }
             }
+        }
+    }
+    
+    private func setupPlayerTimeObserver() {
+        playerTimeObservation = controlsView.player?.observe(\.currentTime, options: [.new]) { [weak self] (_, change) in
+            guard let self = self, let newTime = change.newValue else { return }
+            self.subtitleView.updateSubtitle(at: newTime.doubleValue)
         }
     }
     

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import CoreMedia
 
 
 public class TPStreamPlayerViewController: UIViewController {
@@ -22,12 +23,15 @@ public class TPStreamPlayerViewController: UIViewController {
             player.onError = showError
         }
     }
-    private var playerStatusObervervation: NSKeyValueObservation?
-    private var playerTimeObservation: NSKeyValueObservation?
+    private var playerStatusObservation: NSKeyValueObservation?
+    private var playerTimeObserver: Any?
     
     public var activeSubtitleTrack: SubtitleTrack? {
         didSet {
             subtitleView.setTrack(activeSubtitleTrack)
+            if isViewLoaded {
+                controlsView.selectedSubtitleTrack = activeSubtitleTrack
+            }
         }
     }
     
@@ -67,6 +71,9 @@ public class TPStreamPlayerViewController: UIViewController {
         view.fullScreenToggleDelegate = self
         view.controlsDelegate = self
         view.parentViewController = self
+        view.onSubtitleTrackSelected = { [weak self] track in
+            self?.activeSubtitleTrack = track
+        }
         return view
     }()
     
@@ -102,6 +109,13 @@ public class TPStreamPlayerViewController: UIViewController {
         return messageLabel
     }()
     
+    deinit {
+        playerStatusObservation = nil
+        if let observer = playerTimeObserver, let player = player {
+            player.removeTimeObserver(observer)
+        }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(containerView)
@@ -139,7 +153,7 @@ public class TPStreamPlayerViewController: UIViewController {
     }
     
     private func setupPlayerStatusObserver(for player: TPAVPlayer) {
-        playerStatusObervervation = player.observe(\.initializationStatus, options: [.new]) { [weak self] (_, change) in
+        playerStatusObservation = player.observe(\.initializationStatus, options: [.new]) { [weak self] (_, change) in
             guard let self = self else { return }
 
             if let status = change.newValue {
@@ -150,7 +164,9 @@ public class TPStreamPlayerViewController: UIViewController {
                 case "ready":
                     self.noticeView.isHidden = true
                     self.showLiveStreamNotice()
-                    if self.config.autoSelectFirstSubtitle, let tracks = self.player?.asset?.video?.tracks, let firstTrack = tracks.first {
+                    if self.config.autoSelectFirstSubtitle,
+                       self.activeSubtitleTrack == nil,
+                       let firstTrack = self.player?.asset?.video?.tracks.first {
                         self.activeSubtitleTrack = firstTrack
                     }
                 default:
@@ -161,9 +177,9 @@ public class TPStreamPlayerViewController: UIViewController {
     }
     
     private func setupPlayerTimeObserver() {
-        playerTimeObservation = controlsView.player?.observe(\.currentTime, options: [.new]) { [weak self] (_, change) in
-            guard let self = self, let newTime = change.newValue else { return }
-            self.subtitleView.updateSubtitle(at: newTime.doubleValue)
+        let interval = CMTime(seconds: 0.1, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        playerTimeObserver = player?.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            self?.subtitleView.updateSubtitle(at: CMTimeGetSeconds(time))
         }
     }
     

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -160,11 +160,49 @@ class PlayerControlsUIView: UIView {
              optionsMenu.addAction(UIAlertAction(title: "Playback Speed", style: .default) { _ in self.showPlaybackSpeedMenu()})
         }
         
+        if playerConfig.enableCaptions, let tracks = player.asset?.video?.tracks, !tracks.isEmpty {
+            optionsMenu.addAction(UIAlertAction(title: "Captions", style: .default) { _ in self.showCaptionsMenu()})
+        }
+        
         if !player.player.isPlaybackOffline {
             addOnlinePlaybackButtons(to: optionsMenu)
         }
         optionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         parentViewController?.present(optionsMenu, animated: true, completion: nil)
+    }
+    
+    func showCaptionsMenu() {
+        guard let captionsMenu = createCaptionsMenu() else { return }
+        parentViewController?.present(captionsMenu, animated: true, completion: nil)
+    }
+    
+    func createCaptionsMenu() -> UIAlertController? {
+        guard let tracks = player.asset?.video?.tracks else { return nil }
+        let captionsMenu = UIAlertController(title: "Captions", message: nil, preferredStyle: ACTION_SHEET_PREFERRED_STYLE)
+        
+        captionsMenu.addAction(createActionForCaptionTrack(nil))
+        
+        for track in tracks {
+            let action = createActionForCaptionTrack(track)
+            captionsMenu.addAction(action)
+        }
+        
+        captionsMenu.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        return captionsMenu
+    }
+    
+    func createActionForCaptionTrack(_ track: SubtitleTrack?) -> UIAlertAction {
+        let title = track?.displayName ?? "Off"
+        let action = UIAlertAction(title: title, style: .default) { [weak self] _ in
+            if let playerVC = self?.parentViewController as? TPStreamPlayerViewController {
+                playerVC.activeSubtitleTrack = track
+            }
+        }
+        let activeTrack = (parentViewController as? TPStreamPlayerViewController)?.activeSubtitleTrack
+        if track?.url == activeTrack?.url {
+            action.setValue(UIImage(named: "checkmark", in: bundle, compatibleWith: nil), forKey: "image")
+        }
+        return action
     }
     
     private func addOnlinePlaybackButtons(to menu: UIAlertController) {

--- a/Source/Views/UIKit/PlayerControlsUIView.swift
+++ b/Source/Views/UIKit/PlayerControlsUIView.swift
@@ -49,7 +49,9 @@ class PlayerControlsUIView: UIView {
         }
     }
     
-    var parentViewController: UIViewController?
+    weak var parentViewController: UIViewController?
+    var selectedSubtitleTrack: SubtitleTrack?
+    var onSubtitleTrackSelected: ((SubtitleTrack?) -> Void)?
     var fullScreenToggleDelegate: FullScreenToggleDelegate?
     var controlsDelegate: PlayerControlsDelegate?
     var isFullScreen: Bool = false {
@@ -171,12 +173,12 @@ class PlayerControlsUIView: UIView {
         parentViewController?.present(optionsMenu, animated: true, completion: nil)
     }
     
-    func showCaptionsMenu() {
+    private func showCaptionsMenu() {
         guard let captionsMenu = createCaptionsMenu() else { return }
         parentViewController?.present(captionsMenu, animated: true, completion: nil)
     }
     
-    func createCaptionsMenu() -> UIAlertController? {
+    private func createCaptionsMenu() -> UIAlertController? {
         guard let tracks = player.asset?.video?.tracks else { return nil }
         let captionsMenu = UIAlertController(title: "Captions", message: nil, preferredStyle: ACTION_SHEET_PREFERRED_STYLE)
         
@@ -191,15 +193,13 @@ class PlayerControlsUIView: UIView {
         return captionsMenu
     }
     
-    func createActionForCaptionTrack(_ track: SubtitleTrack?) -> UIAlertAction {
+    private func createActionForCaptionTrack(_ track: SubtitleTrack?) -> UIAlertAction {
         let title = track?.displayName ?? "Off"
         let action = UIAlertAction(title: title, style: .default) { [weak self] _ in
-            if let playerVC = self?.parentViewController as? TPStreamPlayerViewController {
-                playerVC.activeSubtitleTrack = track
-            }
+            self?.selectedSubtitleTrack = track
+            self?.onSubtitleTrackSelected?(track)
         }
-        let activeTrack = (parentViewController as? TPStreamPlayerViewController)?.activeSubtitleTrack
-        if track?.url == activeTrack?.url {
+        if track?.url == selectedSubtitleTrack?.url {
             action.setValue(UIImage(named: "checkmark", in: bundle, compatibleWith: nil), forKey: "image")
         }
         return action

--- a/openspec/changes/add-subtitle-support/tasks.md
+++ b/openspec/changes/add-subtitle-support/tasks.md
@@ -15,16 +15,16 @@
 
 ## 3. UIKit Integration
 
-- [ ] 3.1 Add `autoSelectFirstSubtitle: Bool` to `TPStreamPlayerConfiguration` and builder method
-- [ ] 3.2 Verify `enableCaptions` builder method exists (already in struct)
-- [ ] 3.3 Add `SubtitleView` as lazy var in `TPStreamPlayerViewController` and add as subview of `containerView`
-- [ ] 3.4 Size `SubtitleView` in `viewDidLayoutSubviews`
-- [ ] 3.5 Add "Captions" option to `PlayerControlsUIView.showOptionsMenu()`, only when `enableCaptions == true` and tracks exist
-- [ ] 3.6 Build captions submenu showing available languages with checkmark on active, plus "Off" option
-- [ ] 3.7 On language selection, pass the track to `SubtitleView.setTrack()`; on "Off", pass `nil`
-- [ ] 3.8 Implement auto-selection on player "ready": if `autoSelectFirstSubtitle == true`, auto-set the first available subtitle track
-- [ ] 3.9 Set up KVO on `TPStreamPlayer.currentTime` in VC to push time updates to `SubtitleView.updateSubtitle(at:)`
-- [ ] 3.10 Update `showSettingsButton` to include `enableCaptions`
+- [x] 3.1 Add `autoSelectFirstSubtitle: Bool` to `TPStreamPlayerConfiguration` and builder method
+- [x] 3.2 Verify `enableCaptions` builder method exists (already in struct)
+- [x] 3.3 Add `SubtitleView` as lazy var in `TPStreamPlayerViewController` and add as subview of `containerView`
+- [x] 3.4 Size `SubtitleView` in `viewDidLayoutSubviews`
+- [x] 3.5 Add "Captions" option to `PlayerControlsUIView.showOptionsMenu()`, only when `enableCaptions == true` and tracks exist
+- [x] 3.6 Build captions submenu showing available languages with checkmark on active, plus "Off" option
+- [x] 3.7 On language selection, pass the track to `SubtitleView.setTrack()`; on "Off", pass `nil`
+- [x] 3.8 Implement auto-selection on player "ready": if `autoSelectFirstSubtitle == true`, auto-set the first available subtitle track
+- [x] 3.9 Set up KVO on `TPStreamPlayer.currentTime` in VC to push time updates to `SubtitleView.updateSubtitle(at:)`
+- [x] 3.10 Update `showSettingsButton` to include `enableCaptions`
 
 
 ## 4. SwiftUI Integration


### PR DESCRIPTION
- Integrate subtitle support into the UIKit player.
- Users can view subtitles, switch between available languages, or turn subtitles off from the player controls.
- Automatically select the first available subtitle track when configured.