### PR TITLE
fix: Setup completion fires before video qualities are populated

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -86,8 +86,6 @@ public class TPAVPlayer: AVPlayer {
                 self.processInitializationFailure(error)
                 return
             }
-            self.setupCompletion?(nil)
-            self.initializationStatus = "ready"
         } else {
             self.processInitializationFailure(TPStreamPlayerError.incompleteOfflineVideo)
         }
@@ -138,8 +136,6 @@ public class TPAVPlayer: AVPlayer {
             processInitializationFailure(error)
             return
         }
-        setupCompletion?(nil)
-        initializationStatus = "ready"
     }
     
     private func initializePlayer() throws {
@@ -155,7 +151,11 @@ public class TPAVPlayer: AVPlayer {
         if asset.isDrmEncrypted == true {
             self.setupDRM(avURLAsset)
         }
-        self.populateAvailableVideoQualities(url)
+        self.populateAvailableVideoQualities(url) { [weak self] in
+            self?.setupCompletion?(nil)
+            self?.setupCompletion = nil
+            self?.initializationStatus = "ready"
+        }
     }
     
     private func isNetworkUnavailableError(_ error: Error) -> Bool {
@@ -197,7 +197,7 @@ public class TPAVPlayer: AVPlayer {
         }
     }
     
-    private func populateAvailableVideoQualities(_ url: URL) {
+    private func populateAvailableVideoQualities(_ url: URL, completion: @escaping () -> Void) {
         M3U8Parser.parseQualities(from: url) { [weak self] result in
             switch result {
             case .success(let (qualities, _)):
@@ -207,6 +207,7 @@ public class TPAVPlayer: AVPlayer {
             case .failure:
                 break
             }
+            completion()
         }
     }
     

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -42,6 +42,13 @@ class PlayerViewController: UIViewController {
                 }
 
                 print("TPAVPlayer setup successfully")
+                print("Available qualities: \(self.player?.availableVideoQualities ?? [])")
+                let qualities = self.player?.availableVideoQualities ?? []
+                for quality in qualities {
+                    if quality.resolution == "240p" {
+                        self.player?.changeVideoQuality(to: quality)
+                    }
+                }
             }
         }
         playerViewController = TPStreamPlayerViewController()


### PR DESCRIPTION
- Player initialization completed before video qualities were available.
- Initialization was marked complete before video qualities finished loading.
- Complete initialization only after video qualities have finished loading.