### PR TITLE
fix: False initialization success when playback URL is invalid

### DIFF
--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -80,8 +80,10 @@ public class TPAVPlayer: AVPlayer {
             let asset = localOfflineAsset.asAsset()
             self.asset = asset
             self.resourceLoaderDelegate?.asset = asset
-            guard self.initializePlayer() else {
-                self.processInitializationFailure(TPStreamPlayerError.unknownError)
+            do {
+                try self.initializePlayer()
+            } catch {
+                self.processInitializationFailure(error)
                 return
             }
             self.setupCompletion?(nil)
@@ -130,18 +132,20 @@ public class TPAVPlayer: AVPlayer {
     private func initializePlayerWithFetchedAsset(_ asset: Asset) {
         self.asset = asset
         self.resourceLoaderDelegate?.asset = asset
-        guard initializePlayer() else {
-            processInitializationFailure(TPStreamPlayerError.unknownError)
+        do {
+            try initializePlayer()
+        } catch {
+            processInitializationFailure(error)
             return
         }
         setupCompletion?(nil)
         initializationStatus = "ready"
     }
     
-    private func initializePlayer() -> Bool {
+    private func initializePlayer() throws {
         guard let asset = asset, let urlString = asset.playbackURL, let url = URL(string: urlString) else {
             debugPrint("Invalid playback URL received from API: \(asset?.playbackURL ?? "nil")")
-            return false
+            throw TPStreamPlayerError.unknownError
         }
         
         let avURLAsset = AVURLAsset(url: url)
@@ -152,7 +156,6 @@ public class TPAVPlayer: AVPlayer {
             self.setupDRM(avURLAsset)
         }
         self.populateAvailableVideoQualities(url)
-        return true
     }
     
     private func isNetworkUnavailableError(_ error: Error) -> Bool {

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -127,15 +127,19 @@ public class TPAVPlayer: AVPlayer {
     private func initializePlayerWithFetchedAsset(_ asset: Asset) {
         self.asset = asset
         self.resourceLoaderDelegate?.asset = asset
-        initializePlayer()
+        guard initializePlayer() else {
+            processInitializationFailure(TPStreamPlayerError.unknownError)
+            return
+        }
         setupCompletion?(nil)
         initializationStatus = "ready"
     }
     
-    private func initializePlayer() {
+    @discardableResult
+    private func initializePlayer() -> Bool {
         guard let asset = asset, let urlString = asset.playbackURL, let url = URL(string: urlString) else {
             debugPrint("Invalid playback URL received from API: \(asset?.playbackURL ?? "nil")")
-            return
+            return false
         }
         
         let avURLAsset = AVURLAsset(url: url)
@@ -146,6 +150,7 @@ public class TPAVPlayer: AVPlayer {
             self.setupDRM(avURLAsset)
         }
         self.populateAvailableVideoQualities(url)
+        return true
     }
     
     private func isNetworkUnavailableError(_ error: Error) -> Bool {

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -80,7 +80,10 @@ public class TPAVPlayer: AVPlayer {
             let asset = localOfflineAsset.asAsset()
             self.asset = asset
             self.resourceLoaderDelegate?.asset = asset
-            self.initializePlayer()
+            guard self.initializePlayer() else {
+                self.processInitializationFailure(TPStreamPlayerError.unknownError)
+                return
+            }
             self.setupCompletion?(nil)
             self.initializationStatus = "ready"
         } else {
@@ -135,7 +138,6 @@ public class TPAVPlayer: AVPlayer {
         initializationStatus = "ready"
     }
     
-    @discardableResult
     private func initializePlayer() -> Bool {
         guard let asset = asset, let urlString = asset.playbackURL, let url = URL(string: urlString) else {
             debugPrint("Invalid playback URL received from API: \(asset?.playbackURL ?? "nil")")


### PR DESCRIPTION
- Invalid playback URLs incorrectly reported successful initialization.
- Initialization success was reported even when player setup had already failed, causing failures to be ignored.
- Report initialization failures instead of incorrectly reporting success.