### PR TITLE
fix: Apply CocoaPods compilation flag to all build configurations

### DIFF
--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -20,8 +20,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'SwiftSubtitles', '1.8.1'
 
   spec.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS[config=Debug]' => '-DCocoaPods',
-    'OTHER_SWIFT_FLAGS[config=Release]' => '-DCocoaPods'
+    'OTHER_SWIFT_FLAGS' => '-DCocoaPods'
 }
 
   spec.resources = [

--- a/TPStreamsSDK.podspec
+++ b/TPStreamsSDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'SwiftSubtitles', '1.8.1'
 
   spec.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-DCocoaPods'
+    'OTHER_SWIFT_FLAGS' => '$(inherited) -DCocoaPods'
 }
 
   spec.resources = [


### PR DESCRIPTION
- CocoaPods integrations using custom build configuration names could compile the SDK without the CocoaPods compilation flag, causing the wrong resource-loading path to be used.
- The compilation flag was scoped only to configurations named exactly `Debug` and `Release`, so it wasn't applied to custom configuration names.
- Apply the CocoaPods compilation flag unconditionally so it is available in every CocoaPods build configuration.