### PR TITLE
 feat: Add player seek event callback 

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -232,7 +232,6 @@ class TPStreamPlayer: NSObject {
             return
         }
         let seekTime = CMTimeMakeWithSeconds(seconds, preferredTimescale: 600)
-        player?.onSeek?(CMTimeGetSeconds(seekTime))
         currentTime = NSNumber(value: seconds)
         isSeeking = true
         player?.seek(to: seekTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero){ [weak self] _ in

--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -231,9 +231,9 @@ class TPStreamPlayer: NSObject {
             print("Invalid seconds value: NaN")
             return
         }
-        player?.onSeek?(seconds)
+        let seekTime = CMTimeMakeWithSeconds(seconds, preferredTimescale: 600)
+        player?.onSeek?(CMTimeGetSeconds(seekTime))
         currentTime = NSNumber(value: seconds)
-        let seekTime = CMTime(value: Int64(seconds), timescale: 1)
         isSeeking = true
         player?.seek(to: seekTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero){ [weak self] _ in
             guard let self = self else { return }

--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -231,6 +231,7 @@ class TPStreamPlayer: NSObject {
             print("Invalid seconds value: NaN")
             return
         }
+        player?.onSeek?(seconds)
         currentTime = NSNumber(value: seconds)
         let seekTime = CMTime(value: Int64(seconds), timescale: 1)
         isSeeking = true

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -24,6 +24,7 @@ public class TPAVPlayer: AVPlayer {
     private var setupCompletion: SetupCompletion?
     private var resourceLoaderDelegate: ResourceLoaderDelegate?
     public var onError: ((Error, String?) -> Void)?
+    public var onSeek: ((TimeInterval) -> Void)?
     public var onRequestOfflineLicenseRenewal: ((String, @escaping (String?, Double?) -> Void) -> Void)?
     @objc internal dynamic var initializationStatus = "pending"
     internal var initializationErrorContext: InitializationErrorContext?

--- a/Source/TPAVPlayer.swift
+++ b/Source/TPAVPlayer.swift
@@ -227,6 +227,44 @@ public class TPAVPlayer: AVPlayer {
         }
     }
     
+    // MARK: - Seek Overrides
+
+    public override func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {
+        guard time.seconds.isFinite && time.seconds >= 0 else {
+            print("Invalid seek time: \(time.seconds)")
+            completionHandler(false)
+            return
+        }
+        super.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
+            if finished {
+                self?.onSeek?(CMTimeGetSeconds(time))
+            }
+            completionHandler(finished)
+        }
+    }
+
+    public override func seek(to time: CMTime, completionHandler: @escaping (Bool) -> Void) {
+        guard time.seconds.isFinite && time.seconds >= 0 else {
+            print("Invalid seek time: \(time.seconds)")
+            completionHandler(false)
+            return
+        }
+        super.seek(to: time) { [weak self] finished in
+            if finished {
+                self?.onSeek?(CMTimeGetSeconds(time))
+            }
+            completionHandler(finished)
+        }
+    }
+
+    public override func seek(to time: CMTime) {
+        self.seek(to: time, completionHandler: { _ in })
+    }
+
+    public override func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) {
+        self.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, completionHandler: { _ in })
+    }
+
     deinit {
         reachability?.stopNotifier()
     }

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -52,7 +52,7 @@ class PlayerViewController: UIViewController {
             }
         }
         player?.onSeek = { time in
-            print("Seeked to \(time)s")
+            print("Seeking to \(time)s")
         }
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -52,7 +52,7 @@ class PlayerViewController: UIViewController {
             }
         }
         player?.onSeek = { time in
-            print("Seeking to \(time)s")
+            print("Seeked to \(time)s")
         }
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -51,6 +51,9 @@ class PlayerViewController: UIViewController {
                 }
             }
         }
+        player?.onSeek = { time in
+            print("Seeked to \(time)s")
+        }
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player
         playerViewController?.delegate = self


### PR DESCRIPTION
- Applications had no way to be notified immediately when a seek operation was initiated.
- The SDK did not expose a callback for seek events.
- Added a seek callback that is triggered when a seek is requested and included an example of its usage.