### PR TITLE
fix: Skip live stream notice when recorded video is available

### DIFF
--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -195,6 +195,10 @@ public class TPStreamPlayerViewController: UIViewController {
                 return
             }
         
+        if liveStream.transcodeRecordedVideo && player.asset?.video?.playbackURL != nil {
+            return
+        }
+        
         showNotice(withMessage: noticeMessage)
     }
     

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -195,7 +195,7 @@ public class TPStreamPlayerViewController: UIViewController {
                 return
             }
         
-        if liveStream.transcodeRecordedVideo && player.asset?.video?.playbackURL != nil {
+        if liveStream.transcodeRecordedVideo && player.asset?.video != nil {
             return
         }
         

--- a/Source/ViewModels/TPStreamPlayerViewModel.swift
+++ b/Source/ViewModels/TPStreamPlayerViewModel.swift
@@ -52,7 +52,7 @@ class TPStreamPlayerViewModel: ObservableObject {
                 return
             }
         
-        if liveStream.transcodeRecordedVideo && player.asset?.video?.playbackURL != nil {
+        if liveStream.transcodeRecordedVideo && player.asset?.video != nil {
             return
         }
         

--- a/Source/ViewModels/TPStreamPlayerViewModel.swift
+++ b/Source/ViewModels/TPStreamPlayerViewModel.swift
@@ -52,6 +52,10 @@ class TPStreamPlayerViewModel: ObservableObject {
                 return
             }
         
+        if liveStream.transcodeRecordedVideo && player.asset?.video?.playbackURL != nil {
+            return
+        }
+        
         self.setNoticeMessage(noticeMessage)
     }
     


### PR DESCRIPTION
- Live stream notice ("Stay tuned, recording ready shortly") displayed even when the recording was already transcoded and playable for testpress provider
- showLiveStreamNotice() unconditionally showed the notice without checking if the recorded video was ready
- Suppress notice when transcodeRecordedVideo is true and a valid video playback URL exists (both SwiftUI and UIKit paths)