### PR TITLE
feat: Add offline license duration parameter to download API

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -94,6 +94,7 @@ public final class TPStreamsDownloadManager {
         resolution: String? = nil,
         allowResolutionFallback: Bool = false,
         metadata: [String: Any]? = nil,
+        offlineLicenseDurationSeconds: Double? = nil,
         presentingViewController: UIViewController? = nil,
         completion: ((Result<OfflineAsset, TPDownloadError>) -> Void)? = nil
     ) {
@@ -135,7 +136,7 @@ public final class TPStreamsDownloadManager {
                         }
                         
                         do {
-                            try self.enqueueDownload(asset: asset, accessToken: token, videoQuality: quality, playlistModel: playlistModel, metadata: metadata)
+                            try self.enqueueDownload(asset: asset, accessToken: token, videoQuality: quality, playlistModel: playlistModel, metadata: metadata, offlineLicenseDurationSeconds: offlineLicenseDurationSeconds)
                             
                             if let offlineAsset = LocalOfflineAsset.manager.get(id: asset.id) {
                                 completion?(.success(offlineAsset.asOfflineAsset()))
@@ -146,7 +147,7 @@ public final class TPStreamsDownloadManager {
                             completion?(.failure(.downloadExecutionFailed(error)))
                         }
                     } else if let presentingViewController = presentingViewController {
-                        self.showQualityPicker(asset: asset, token: token, qualities: qualities, playlistModel: playlistModel, metadata: metadata, on: presentingViewController, completion: completion)
+                        self.showQualityPicker(asset: asset, token: token, qualities: qualities, playlistModel: playlistModel, metadata: metadata, offlineLicenseDurationSeconds: offlineLicenseDurationSeconds, on: presentingViewController, completion: completion)
                     } else {
                         completion?(.failure(.resolutionRequired))
                     }
@@ -161,6 +162,7 @@ public final class TPStreamsDownloadManager {
         qualities: [VideoQuality],
         playlistModel: M3U8PlaylistModel,
         metadata: [String: Any]? = nil,
+        offlineLicenseDurationSeconds: Double? = nil,
         on viewController: UIViewController,
         completion: ((Result<OfflineAsset, TPDownloadError>) -> Void)?
     ) {
@@ -169,7 +171,7 @@ public final class TPStreamsDownloadManager {
         for quality in qualities {
             alert.addAction(UIAlertAction(title: quality.resolution, style: .default) { _ in
                 do {
-                    try self.enqueueDownload(asset: asset, accessToken: token, videoQuality: quality, playlistModel: playlistModel, metadata: metadata)
+                    try self.enqueueDownload(asset: asset, accessToken: token, videoQuality: quality, playlistModel: playlistModel, metadata: metadata, offlineLicenseDurationSeconds: offlineLicenseDurationSeconds)
                     
                     if let offlineAsset = LocalOfflineAsset.manager.get(id: asset.id) {
                         completion?(.success(offlineAsset.asOfflineAsset()))

--- a/StoryboardExample/MainViewController.swift
+++ b/StoryboardExample/MainViewController.swift
@@ -23,10 +23,11 @@ class MainViewController: UIViewController {
     
     @IBAction func downloadTapped(_ sender: UIButton) {
         TPStreamsDownloadManager.shared.startDownload(
-            assetID: "BEArYFdaFbt",
-            accessToken: "ecf6366b-c2ee-408c-9472-6ed4e4b3047e",
+            assetID: "42h2tZ5fmNf",
+            accessToken: "9327e2d0-fa13-4288-902d-840f32cd0eed",
             resolution: "140p",
             allowResolutionFallback: true,
+            // offlineLicenseDurationSeconds: 30,
             presentingViewController: self,
         ) { result in
             switch result {

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -51,12 +51,6 @@ class PlayerViewController: UIViewController {
                 }
             }
         }
-        
-        player?.onRequestOfflineLicenseRenewal = { assetId, completion in
-            print("====> onRequestOfflineLicenseRenewal is called for asset: \(assetId) <====")
-            completion(nil, nil)
-        }
-        
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player
         playerViewController?.delegate = self

--- a/StoryboardExample/PlayerViewController.swift
+++ b/StoryboardExample/PlayerViewController.swift
@@ -51,6 +51,12 @@ class PlayerViewController: UIViewController {
                 }
             }
         }
+        
+        player?.onRequestOfflineLicenseRenewal = { assetId, completion in
+            print("====> onRequestOfflineLicenseRenewal is called for asset: \(assetId) <====")
+            completion(nil, nil)
+        }
+        
         playerViewController = TPStreamPlayerViewController()
         playerViewController?.player = player
         playerViewController?.delegate = self


### PR DESCRIPTION
- Downloaded content always used the default offline license duration, making it impossible to configure different expiration periods for different download scenarios.
- This happened because the offline download API did not accept a license duration when initiating a download.
- This is fixed by allowing a custom offline license duration to be provided when starting a download, ensuring it is preserved throughout the download flow, including quality selection, and applied when the download is queued.