### PR TITLE
refactor: Make offline asset deletion thread-safe

### DIFF
--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -388,11 +388,9 @@ public final class TPStreamsDownloadManager {
                 }
 
                 if let drmContentId = drmContentId, !drmContentId.isEmpty {
-                    // Key file name must match getPersistentContentKeyURL in
-                    // ContentKeyDelegate+Persistable. Deleting directly avoids touching
-                    // the shared delegate's mutable contentID/assetID, which in-flight
-                    // key requests read.
-                    let keyURL = self.contentKeyDelegate.contentKeyDirectory.appendingPathComponent("\(drmContentId)-Key")
+                    // Deleting directly avoids touching the shared delegate's mutable
+                    // contentID/assetID, which in-flight key requests read.
+                    let keyURL = self.contentKeyDelegate.contentKeyDirectory.appendingPathComponent(ContentKeyDelegate.persistentContentKeyFileName(for: drmContentId))
                     try? FileManager.default.removeItem(at: keyURL)
                     self.updateOfflineLicenseExpiry(assetId, expiryDate: nil)
                 }

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -380,13 +380,6 @@ public final class TPStreamsDownloadManager {
             do {
                 try FileManager.default.removeItem(at: downloadedFileURL)
 
-                let finishDeletion = {
-                    self.deleteEncryptionKey(for: assetId)
-                    DispatchQueue.main.async {
-                        completion(true, nil)
-                    }
-                }
-
                 if let drmContentId = drmContentId, !drmContentId.isEmpty {
                     // Deleting directly avoids touching the shared delegate's mutable
                     // contentID/assetID, which in-flight key requests read.
@@ -394,7 +387,11 @@ public final class TPStreamsDownloadManager {
                     try? FileManager.default.removeItem(at: keyURL)
                     self.updateOfflineLicenseExpiry(assetId, expiryDate: nil)
                 }
-                finishDeletion()
+
+                self.deleteEncryptionKey(for: assetId)
+                DispatchQueue.main.async {
+                    completion(true, nil)
+                }
             } catch {
                 DispatchQueue.main.async {
                     completion(false, error)

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -324,7 +324,7 @@ public final class TPStreamsDownloadManager {
         }
         
         guard let fileURL = localOfflineAsset.downloadedFileURL else {
-            deleteEncryptionKey(for: localOfflineAsset)
+            deleteEncryptionKey(for: assetId)
             LocalOfflineAsset.manager.delete(id: assetId)
             if hasActiveTask == nil {
                 tpStreamsDownloadDelegate?.onCanceled(assetId: assetId)
@@ -332,7 +332,7 @@ public final class TPStreamsDownloadManager {
             return
         }
         
-        deleteDownloadedFile(fileURL, localOfflineAsset: localOfflineAsset) { [weak self] success, error in
+        deleteDownloadedFile(fileURL, assetId: assetId, drmContentId: localOfflineAsset.drmContentId) { [weak self] success, error in
             if success {
                 LocalOfflineAsset.manager.delete(id: assetId)
                 if hasActiveTask == nil {
@@ -357,31 +357,47 @@ public final class TPStreamsDownloadManager {
               localOfflineAsset.status == Status.finished.rawValue,
               localOfflineAsset.downloadedFileURL != nil else { return }
         
-        LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["status": Status.deleted.rawValue])
-        tpStreamsDownloadDelegate?.onDelete(assetId: localOfflineAsset.assetId)
+        let assetId = localOfflineAsset.assetId
+        let drmContentId = localOfflineAsset.drmContentId
+        let downloadedFileURL = localOfflineAsset.downloadedFileURL!
         
-        self.deleteDownloadedFile(localOfflineAsset.downloadedFileURL!, localOfflineAsset: localOfflineAsset) { success, error in
+        LocalOfflineAsset.manager.update(object: localOfflineAsset, with: ["status": Status.deleted.rawValue])
+        tpStreamsDownloadDelegate?.onDelete(assetId: assetId)
+        
+        self.deleteDownloadedFile(downloadedFileURL, assetId: assetId, drmContentId: drmContentId) { success, error in
             if success {
-                LocalOfflineAsset.manager.delete(id: localOfflineAsset.assetId)
+                LocalOfflineAsset.manager.delete(id: assetId)
             } else {
-                print("An error occurred trying to delete the contents on disk for \(localOfflineAsset.assetId): \(String(describing: error))")
+                print("An error occurred trying to delete the contents on disk for \(assetId): \(String(describing: error))")
             }
         }
     }
     
-    private func deleteDownloadedFile(_ downloadedFileURL: URL, localOfflineAsset: LocalOfflineAsset, completion: @escaping (Bool, Error?) -> Void) {
+    private func deleteDownloadedFile(_ downloadedFileURL: URL, assetId: String, drmContentId: String?, completion: @escaping (Bool, Error?) -> Void) {
+        // assetId / drmContentId must be plain values copied on the Realm thread —
+        // never pass a LocalOfflineAsset into this background work.
         DispatchQueue.global(qos: .background).async {
             do {
                 try FileManager.default.removeItem(at: downloadedFileURL)
-                
-                DispatchQueue.main.async {
-                    if localOfflineAsset.drmContentId != nil {
-                        self.contentKeyDelegate.cleanupPersistentContentKey()
+
+                let finishDeletion = {
+                    self.deleteEncryptionKey(for: assetId)
+                    DispatchQueue.main.async {
+                        completion(true, nil)
                     }
-                    
-                    self.deleteEncryptionKey(for: localOfflineAsset)
-                    
-                    completion(true, nil)
+                }
+
+                if let drmContentId = drmContentId, !drmContentId.isEmpty {
+                    // Delegate access must be on contentKeyDelegateQueue to avoid
+                    // racing with key-request callbacks that read/write contentID/assetID.
+                    self.contentKeyDelegateQueue.async {
+                        self.contentKeyDelegate.contentID = drmContentId
+                        self.contentKeyDelegate.assetID = assetId
+                        self.contentKeyDelegate.cleanupPersistentContentKey()
+                        finishDeletion()
+                    }
+                } else {
+                    finishDeletion()
                 }
             } catch {
                 DispatchQueue.main.async {
@@ -391,8 +407,8 @@ public final class TPStreamsDownloadManager {
         }
     }
 
-    internal func deleteEncryptionKey(for localOfflineAsset: LocalOfflineAsset) {
-        encryptionKeyDelegate.delete(for: localOfflineAsset.assetId)
+    internal func deleteEncryptionKey(for assetId: String) {
+        encryptionKeyDelegate.delete(for: assetId)
     }
     
     public func getAllOfflineAssets() -> [OfflineAsset] {
@@ -519,7 +535,7 @@ internal class AssetDownloadDelegate: NSObject, AVAssetDownloadDelegate {
         }()
         
         if status == .failed || status == .deleted {
-            TPStreamsDownloadManager.shared.deleteEncryptionKey(for: localOfflineAsset)
+            TPStreamsDownloadManager.shared.deleteEncryptionKey(for: localOfflineAsset.assetId)
         }
         
         let updateValues: [String: Any] = ["status": status.rawValue, "downloadedAt": Date()]

--- a/Source/Database/TPStreamsDownloadManager.swift
+++ b/Source/Database/TPStreamsDownloadManager.swift
@@ -388,17 +388,15 @@ public final class TPStreamsDownloadManager {
                 }
 
                 if let drmContentId = drmContentId, !drmContentId.isEmpty {
-                    // Delegate access must be on contentKeyDelegateQueue to avoid
-                    // racing with key-request callbacks that read/write contentID/assetID.
-                    self.contentKeyDelegateQueue.async {
-                        self.contentKeyDelegate.contentID = drmContentId
-                        self.contentKeyDelegate.assetID = assetId
-                        self.contentKeyDelegate.cleanupPersistentContentKey()
-                        finishDeletion()
-                    }
-                } else {
-                    finishDeletion()
+                    // Key file name must match getPersistentContentKeyURL in
+                    // ContentKeyDelegate+Persistable. Deleting directly avoids touching
+                    // the shared delegate's mutable contentID/assetID, which in-flight
+                    // key requests read.
+                    let keyURL = self.contentKeyDelegate.contentKeyDirectory.appendingPathComponent("\(drmContentId)-Key")
+                    try? FileManager.default.removeItem(at: keyURL)
+                    self.updateOfflineLicenseExpiry(assetId, expiryDate: nil)
                 }
+                finishDeletion()
             } catch {
                 DispatchQueue.main.async {
                     completion(false, error)

--- a/Source/Managers/ContentKeyDelegate+Persistable.swift
+++ b/Source/Managers/ContentKeyDelegate+Persistable.swift
@@ -119,7 +119,11 @@ extension ContentKeyDelegate {
     func getPersistentContentKeyURL() -> URL?{
         guard let contentID = self.contentID else { return nil }
         
-        return contentKeyDirectory.appendingPathComponent("\(contentID)-Key")
+        return contentKeyDirectory.appendingPathComponent(Self.persistentContentKeyFileName(for: contentID))
+    }
+    
+    static func persistentContentKeyFileName(for contentID: String) -> String {
+        "\(contentID)-Key"
     }
 
     private func requestOfflineLicenseCredentials(completion: @escaping () -> Void) {


### PR DESCRIPTION
- Deleting an offline asset could race or crash because the asset's database object was accessed from background threads after its row was removed.
- Realm objects may only be used on the thread that created them, so passing the object into background work was unsafe.
- Deletion now carries only the plain asset id and content id across threads, and encryption-key cleanup runs on the content key delegate queue alongside key-request callbacks.