### PR TITLE
feat: Increase subtitle font size in fullscreen

### DIFF
--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -31,7 +31,8 @@ public struct TPStreamPlayerView: View {
                     if playerViewConfig.enableCaptions, let activeSubtitleTrack = activeSubtitleTrack {
                         SubtitleTextView(
                             track: activeSubtitleTrack,
-                            currentTime: playerObservable.observedCurrentTime
+                            currentTime: playerObservable.observedCurrentTime,
+                            isFullScreen: viewModel.isFullScreen
                         )
                     }
                     

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -50,6 +50,7 @@ public class TPStreamPlayerViewController: UIViewController {
     public private(set) var isFullScreen: Bool = false {
         didSet {
             controlsView.isFullScreen = isFullScreen
+            subtitleView.isFullScreen = isFullScreen
             setNeedsStatusBarAppearanceUpdate()
         }
     }

--- a/Source/Views/SwiftUI/SubtitleTextView.swift
+++ b/Source/Views/SwiftUI/SubtitleTextView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SubtitleTextView: UIViewRepresentable {
     let track: SubtitleTrack
     let currentTime: Float64?
+    let isFullScreen: Bool
 
     func makeUIView(context: Context) -> SubtitleView {
         let view = SubtitleView(frame: .zero)
@@ -12,6 +13,7 @@ struct SubtitleTextView: UIViewRepresentable {
 
     func updateUIView(_ uiView: SubtitleView, context: Context) {
         uiView.setTrack(track)
+        uiView.isFullScreen = isFullScreen
 
         if let currentTime = currentTime {
             uiView.updateSubtitle(at: currentTime)

--- a/Source/Views/UIKit/SubtitleView.swift
+++ b/Source/Views/UIKit/SubtitleView.swift
@@ -3,12 +3,22 @@ import SwiftSubtitles
 
 class SubtitleView: UIView {
 
+    static let subtitleFontSize: CGFloat = 14
+    static let fullScreenSubtitleFontSize: CGFloat = subtitleFontSize + 1
+
     private let container = UIView()
     private let label = UILabel()
     private var currentTrack: SubtitleTrack?
     private var downloadTask: URLSessionDataTask?
     private var subtitles: Subtitles?
     private var lastUpdateTime: TimeInterval?
+
+    var isFullScreen = false {
+        didSet {
+            guard isFullScreen != oldValue else { return }
+            updateFontSize()
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,11 +56,15 @@ class SubtitleView: UIView {
 
     private func createLabel() {
         label.textColor = .white
-        label.font = UIFont.systemFont(ofSize: 14)
+        label.font = UIFont.systemFont(ofSize: isFullScreen ? Self.fullScreenSubtitleFontSize : Self.subtitleFontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
         label.lineBreakMode = .byWordWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func updateFontSize() {
+        label.font = UIFont.systemFont(ofSize: isFullScreen ? Self.fullScreenSubtitleFontSize : Self.subtitleFontSize)
     }
 
     private func setupConstraints() {

--- a/Source/Views/UIKit/SubtitleView.swift
+++ b/Source/Views/UIKit/SubtitleView.swift
@@ -4,7 +4,7 @@ import SwiftSubtitles
 class SubtitleView: UIView {
 
     static let subtitleFontSize: CGFloat = 14
-    static let fullScreenSubtitleFontSize: CGFloat = subtitleFontSize + 1
+    static let fullScreenSubtitleFontSize: CGFloat = 16
 
     private let container = UIView()
     private let label = UILabel()
@@ -56,7 +56,7 @@ class SubtitleView: UIView {
 
     private func createLabel() {
         label.textColor = .white
-        label.font = UIFont.systemFont(ofSize: isFullScreen ? Self.fullScreenSubtitleFontSize : Self.subtitleFontSize)
+        updateFontSize()
         label.numberOfLines = 0
         label.textAlignment = .center
         label.lineBreakMode = .byWordWrapping

--- a/StoryboardExample/MainViewController.swift
+++ b/StoryboardExample/MainViewController.swift
@@ -44,7 +44,7 @@ class MainViewController: UIViewController {
     }
     
     @IBAction func sample2Tapped(_ sender: UIButton) {
-        presentPlayerViewController(assistId: "57gHcHDBxKX", accessToken: "5e28479d-69d8-41c7-9664-79b7eb8f1f95")
+        presentPlayerViewController(assistId: "BEArYFdaFbt", accessToken: "e6a1b485-daad-42eb-8cf2-6b6e51631092")
     }
     
     @IBAction func sample3Tapped(_ sender: UIButton) {


### PR DESCRIPTION
- Subtitles previously rendered at the same size in fullscreen as in the inline player, making them harder to read on larger displays.
- Fullscreen subtitles now render one point larger for better readability.
- Subtitle font sizes are now named constants, so adjusting them is a