### PR TITLE
 feat: Reserve layout space for two-line subtitles in inline and fullscreen

### DIFF
--- a/Source/Views/UIKit/SubtitleView.swift
+++ b/Source/Views/UIKit/SubtitleView.swift
@@ -6,6 +6,16 @@ class SubtitleView: UIView {
     static let subtitleFontSize: CGFloat = 14
     static let fullScreenSubtitleFontSize: CGFloat = 16
 
+    static let maxSubtitleLines = 2
+    static let subtitleVerticalPadding: CGFloat = 3
+    static let subtitleBottomInset: CGFloat = 20
+
+    static var reservedBottomBandHeight: CGFloat {
+        CGFloat(maxSubtitleLines) * UIFont.systemFont(ofSize: fullScreenSubtitleFontSize).lineHeight
+            + 2 * subtitleVerticalPadding
+            + subtitleBottomInset
+    }
+
     private let container = UIView()
     private let label = UILabel()
     private var currentTrack: SubtitleTrack?
@@ -57,7 +67,7 @@ class SubtitleView: UIView {
     private func createLabel() {
         label.textColor = .white
         updateFontSize()
-        label.numberOfLines = 0
+        label.numberOfLines = SubtitleView.maxSubtitleLines
         label.textAlignment = .center
         label.lineBreakMode = .byWordWrapping
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Source/Views/UIKit/SubtitleView.swift
+++ b/Source/Views/UIKit/SubtitleView.swift
@@ -69,7 +69,7 @@ class SubtitleView: UIView {
         updateFontSize()
         label.numberOfLines = SubtitleView.maxSubtitleLines
         label.textAlignment = .center
-        label.lineBreakMode = .byWordWrapping
+        label.lineBreakMode = .byTruncatingTail
         label.translatesAutoresizingMaskIntoConstraints = false
     }
 


### PR DESCRIPTION

- Long subtitles could expand across the video due to unlimited line wrapping. They are now limited to 2 lines, with overflow truncated using an ellipsis.
- Expose the maximum subtitle area height based on font metrics, padding, and bottom inset.
- The reserved height uses fullscreen font sizing, keeping watermarks above subtitles in both inline and fullscreen modes.