### PR TITLE
feat: add animated watermark support to the player

### DIFF
--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -32,7 +32,8 @@ public struct TPStreamPlayerView: View {
                         watermarks: playerViewConfig.watermarks,
                         reservedBottomHeight: playerViewConfig.enableCaptions && activeSubtitleTrack != nil
                             ? SubtitleView.reservedBottomBandHeight
-                            : 0
+                            : 0,
+                        labelsAreFrozen: playerObservable.observedStatus != "playing"
                     )
                     
                     if playerViewConfig.enableCaptions, let activeSubtitleTrack = activeSubtitleTrack {

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -22,12 +22,14 @@ public class TPStreamPlayerViewController: UIViewController {
                 handlePlayerInitializationError()
             }
             setupPlayerStatusObserver(for: player)
+            setupPlayerTimeControlObserver(for: player)
             setupPlayerTimeObserver()
             showLiveStreamNotice()
             player.onError = showError
         }
     }
     private var playerStatusObservation: NSKeyValueObservation?
+    private var playerTimeControlObservation: NSKeyValueObservation?
     private var playerTimeObserver: Any?
     
     public var activeSubtitleTrack: SubtitleTrack? {
@@ -127,6 +129,7 @@ public class TPStreamPlayerViewController: UIViewController {
     
     deinit {
         playerStatusObservation = nil
+        playerTimeControlObservation = nil
         if let observer = playerTimeObserver, let player = player {
             player.removeTimeObserver(observer)
         }
@@ -192,6 +195,22 @@ public class TPStreamPlayerViewController: UIViewController {
                     break
                 }
             }
+        }
+    }
+    
+    private func setupPlayerTimeControlObserver(for player: TPAVPlayer) {
+        playerTimeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            guard let self = self else { return }
+            if player.timeControlStatus == .playing {
+                self.watermarkOverlayView.resumeWatermarks()
+            } else {
+                self.watermarkOverlayView.pauseWatermarks()
+            }
+        }
+        if player.timeControlStatus == .playing {
+            watermarkOverlayView.resumeWatermarks()
+        } else {
+            watermarkOverlayView.pauseWatermarks()
         }
     }
     

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -6,13 +6,10 @@ class WatermarkOverlayView: UIView {
     private let inset: CGFloat = 16
     /// Minimum gap kept between the watermark and the reserved bottom band.
     private let reservedBandGap: CGFloat = 4
-    private static let animationKey = "watermarkAnimation"
-
     private var watermarks: [WatermarkConfig] = []
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
     private var labelsAreFrozen = false
-    private var watermarkSpans: [ObjectIdentifier: CGFloat] = [:]
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -69,12 +66,12 @@ class WatermarkOverlayView: UIView {
             label.layer.transform = CATransform3DIdentity
             label.frame = positionedFrame(for: label, at: config)
             if let animation = config.animation {
-                restartAnimationIfSpanChanged(animation, on: label)
+                let span = max(bounds.width - label.frame.width - 2 * inset, 0)
+                label.layer.removeAllAnimations()
+                label.layer.add(makeAnimation(for: animation, span: span), forKey: "watermarkAnimation")
                 if labelsAreFrozen {
                     pauseLayer(label.layer)
                 }
-            } else {
-                watermarkSpans.removeValue(forKey: ObjectIdentifier(label))
             }
         }
     }
@@ -94,7 +91,6 @@ class WatermarkOverlayView: UIView {
     private func rebuildWatermarkLabels() {
         labels.forEach { $0.removeFromSuperview() }
         labels = watermarks.map(watermarkLabel(for:))
-        watermarkSpans.removeAll()
         labels.reversed().forEach(addSubview)
     }
 
@@ -125,19 +121,6 @@ class WatermarkOverlayView: UIView {
         }
         let y = top + (bottomLimit - top) * CGFloat(config.y) / 100
         return CGRect(origin: CGPoint(x: x, y: y), size: size)
-    }
-
-    private func restartAnimationIfSpanChanged(_ animation: WatermarkAnimation, on label: UILabel) {
-        let span = max(bounds.width - label.frame.width - 2 * inset, 0)
-        let labelID = ObjectIdentifier(label)
-        // Rebuild if the travel distance changed, or if the animation was dropped
-        // (e.g. when the view is detached from the window during a fullscreen transition).
-        let hasAnimation = label.layer.animation(forKey: Self.animationKey) != nil
-        guard watermarkSpans[labelID] != span || !hasAnimation else { return }
-        watermarkSpans[labelID] = span
-        label.layer.transform = CATransform3DIdentity
-        label.layer.removeAllAnimations()
-        label.layer.add(makeAnimation(for: animation, span: span), forKey: Self.animationKey)
     }
 
     private func pauseLayer(_ layer: CALayer) {

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -10,8 +10,8 @@ class WatermarkOverlayView: UIView {
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
     private var labelsAreFrozen = false
-    private var animationProgress: [ObjectIdentifier: Double] = [:]
-    private var lastSpan: [ObjectIdentifier: CGFloat] = [:]
+    private var animationStartTimeByLabelID: [ObjectIdentifier: CFTimeInterval] = [:]
+    private var horizontalSpanByLabelID: [ObjectIdentifier: CGFloat] = [:]
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -50,12 +50,6 @@ class WatermarkOverlayView: UIView {
         guard !labelsAreFrozen else { return }
         labelsAreFrozen = true
         for (label, config) in zip(labels, watermarks) where config.animation != nil {
-            let labelID = ObjectIdentifier(label)
-            let anim = label.layer.animation(forKey: "watermarkAnimation")
-            if let anim = anim {
-                let elapsed = anim.timeOffset
-                animationProgress[labelID] = elapsed / anim.duration
-            }
             pauseLayer(label.layer)
         }
     }
@@ -70,29 +64,39 @@ class WatermarkOverlayView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        let now = CACurrentMediaTime()
         for (label, config) in zip(labels, watermarks) {
             label.layer.transform = CATransform3DIdentity
             label.frame = positionedFrame(for: label, at: config)
             if let animation = config.animation {
-                let span = max(bounds.width - label.frame.width - 2 * inset, 0)
-                let labelID = ObjectIdentifier(label)
-                let previousSpan = lastSpan[labelID]
-                lastSpan[labelID] = span
-                let anim = makeAnimation(for: animation, span: span)
-                if let previousSpan = previousSpan, previousSpan > 0 {
-                    let currentProgress = animationProgress[labelID] ?? 0
-                    anim.timeOffset = anim.duration * currentProgress
-                }
-                label.layer.removeAllAnimations()
-                label.layer.add(anim, forKey: "watermarkAnimation")
-                if labelsAreFrozen {
-                    pauseLayer(label.layer)
-                }
+                applyAnimation(animation, to: label, now: now)
             } else {
                 let labelID = ObjectIdentifier(label)
-                animationProgress.removeValue(forKey: labelID)
-                lastSpan.removeValue(forKey: labelID)
+                animationStartTimeByLabelID.removeValue(forKey: labelID)
+                horizontalSpanByLabelID.removeValue(forKey: labelID)
             }
+        }
+    }
+
+    private func applyAnimation(_ animation: WatermarkAnimation, to label: UILabel, now: CFTimeInterval) {
+        let horizontalSpan = max(bounds.width - label.frame.width - 2 * inset, 0)
+        let labelID = ObjectIdentifier(label)
+        let storedStartTime = animationStartTimeByLabelID[labelID]
+        let storedHorizontalSpan = horizontalSpanByLabelID[labelID]
+        horizontalSpanByLabelID[labelID] = horizontalSpan
+
+        let layerAnimation = makeAnimation(for: animation, horizontalSpan: horizontalSpan)
+        if let storedStartTime, let storedHorizontalSpan, storedHorizontalSpan > 0 {
+            let elapsedSinceStart = now - storedStartTime
+            let roundTripDuration = layerAnimation.duration * 2
+            layerAnimation.timeOffset = elapsedSinceStart.truncatingRemainder(dividingBy: roundTripDuration)
+        }
+
+        label.layer.removeAllAnimations()
+        label.layer.add(layerAnimation, forKey: "watermarkAnimation")
+        animationStartTimeByLabelID[labelID] = now
+        if labelsAreFrozen {
+            pauseLayer(label.layer)
         }
     }
 
@@ -112,8 +116,8 @@ class WatermarkOverlayView: UIView {
     private func rebuildWatermarkLabels() {
         labels.forEach { $0.removeFromSuperview() }
         labels = watermarks.map(watermarkLabel(for:))
-        animationProgress.removeAll()
-        lastSpan.removeAll()
+        animationStartTimeByLabelID.removeAll()
+        horizontalSpanByLabelID.removeAll()
         labels.reversed().forEach(addSubview)
     }
 
@@ -161,16 +165,16 @@ class WatermarkOverlayView: UIView {
         layer.beginTime = timeSincePause
     }
 
-    private func makeAnimation(for animation: WatermarkAnimation, span: CGFloat) -> CAAnimation {
+    private func makeAnimation(for animation: WatermarkAnimation, horizontalSpan: CGFloat) -> CAAnimation {
         switch animation.type {
         case .pingPong:
-            return makePingPongAnimation(span: span, duration: animation.duration)
+            return makePingPongAnimation(horizontalSpan: horizontalSpan, duration: animation.duration)
         }
     }
 
-    private func makePingPongAnimation(span: CGFloat, duration: Int64) -> CAKeyframeAnimation {
+    private func makePingPongAnimation(horizontalSpan: CGFloat, duration: Int64) -> CAKeyframeAnimation {
         let keyframe = CAKeyframeAnimation(keyPath: "transform.translation.x")
-        keyframe.values = [0, span]
+        keyframe.values = [0, horizontalSpan]
         keyframe.keyTimes = [0, 1]
         keyframe.duration = Double(duration) / 1000
         keyframe.autoreverses = true

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -10,6 +10,8 @@ class WatermarkOverlayView: UIView {
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
     private var labelsAreFrozen = false
+    private var animationProgress: [ObjectIdentifier: Double] = [:]
+    private var lastSpan: [ObjectIdentifier: CGFloat] = [:]
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -48,6 +50,12 @@ class WatermarkOverlayView: UIView {
         guard !labelsAreFrozen else { return }
         labelsAreFrozen = true
         for (label, config) in zip(labels, watermarks) where config.animation != nil {
+            let labelID = ObjectIdentifier(label)
+            let anim = label.layer.animation(forKey: "watermarkAnimation")
+            if let anim = anim {
+                let elapsed = anim.timeOffset
+                animationProgress[labelID] = elapsed / anim.duration
+            }
             pauseLayer(label.layer)
         }
     }
@@ -67,11 +75,23 @@ class WatermarkOverlayView: UIView {
             label.frame = positionedFrame(for: label, at: config)
             if let animation = config.animation {
                 let span = max(bounds.width - label.frame.width - 2 * inset, 0)
+                let labelID = ObjectIdentifier(label)
+                let previousSpan = lastSpan[labelID]
+                lastSpan[labelID] = span
+                let anim = makeAnimation(for: animation, span: span)
+                if let previousSpan = previousSpan, previousSpan > 0 {
+                    let currentProgress = animationProgress[labelID] ?? 0
+                    anim.timeOffset = anim.duration * currentProgress
+                }
                 label.layer.removeAllAnimations()
-                label.layer.add(makeAnimation(for: animation, span: span), forKey: "watermarkAnimation")
+                label.layer.add(anim, forKey: "watermarkAnimation")
                 if labelsAreFrozen {
                     pauseLayer(label.layer)
                 }
+            } else {
+                let labelID = ObjectIdentifier(label)
+                animationProgress.removeValue(forKey: labelID)
+                lastSpan.removeValue(forKey: labelID)
             }
         }
     }
@@ -92,6 +112,8 @@ class WatermarkOverlayView: UIView {
     private func rebuildWatermarkLabels() {
         labels.forEach { $0.removeFromSuperview() }
         labels = watermarks.map(watermarkLabel(for:))
+        animationProgress.removeAll()
+        lastSpan.removeAll()
         labels.reversed().forEach(addSubview)
     }
 
@@ -131,9 +153,12 @@ class WatermarkOverlayView: UIView {
     }
 
     private func resumeLayer(_ layer: CALayer) {
+        let pausedTime = layer.timeOffset
         layer.speed = 1
         layer.timeOffset = 0
         layer.beginTime = 0
+        let timeSincePause = layer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+        layer.beginTime = timeSincePause
     }
 
     private func makeAnimation(for animation: WatermarkAnimation, span: CGFloat) -> CAAnimation {

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -76,6 +76,7 @@ class WatermarkOverlayView: UIView {
         }
     }
 
+    /// Clamps out-of-range values to valid bounds for watermark configuration.
     private func clampedToValidBounds(_ config: WatermarkConfig) -> WatermarkConfig {
         var config = config
         config.x = min(max(config.x, 0), 100)

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -6,9 +6,13 @@ class WatermarkOverlayView: UIView {
     private let inset: CGFloat = 16
     /// Minimum gap kept between the watermark and the reserved bottom band.
     private let reservedBandGap: CGFloat = 4
+    private static let animationKey = "watermarkAnimation"
+
     private var watermarks: [WatermarkConfig] = []
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
+    private var labelsAreFrozen = false
+    private var watermarkSpans: [ObjectIdentifier: CGFloat] = [:]
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -43,25 +47,54 @@ class WatermarkOverlayView: UIView {
         setNeedsLayout()
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        for (label, config) in zip(labels, watermarks) {
-            label.frame = positionedFrame(for: label, at: config)
+    func pauseWatermarks() {
+        guard !labelsAreFrozen else { return }
+        labelsAreFrozen = true
+        for (label, config) in zip(labels, watermarks) where config.animation != nil {
+            pauseLayer(label.layer)
         }
     }
 
-    /// Clamps out-of-range values to valid bounds for watermark configuration.
+    func resumeWatermarks() {
+        guard labelsAreFrozen else { return }
+        labelsAreFrozen = false
+        for (label, config) in zip(labels, watermarks) where config.animation != nil {
+            resumeLayer(label.layer)
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        for (label, config) in zip(labels, watermarks) {
+            label.layer.transform = CATransform3DIdentity
+            label.frame = positionedFrame(for: label, at: config)
+            if let animation = config.animation {
+                restartAnimationIfSpanChanged(animation, on: label)
+                if labelsAreFrozen {
+                    pauseLayer(label.layer)
+                }
+            } else {
+                watermarkSpans.removeValue(forKey: ObjectIdentifier(label))
+            }
+        }
+    }
+
     private func clampedToValidBounds(_ config: WatermarkConfig) -> WatermarkConfig {
         var config = config
         config.x = min(max(config.x, 0), 100)
         config.y = min(max(config.y, 0), 100)
         config.opacity = min(max(config.opacity, 0), 1)
+        if var animation = config.animation, animation.duration < 100 {
+            animation.duration = 100
+            config.animation = animation
+        }
         return config
     }
 
     private func rebuildWatermarkLabels() {
         labels.forEach { $0.removeFromSuperview() }
         labels = watermarks.map(watermarkLabel(for:))
+        watermarkSpans.removeAll()
         labels.reversed().forEach(addSubview)
     }
 
@@ -79,7 +112,8 @@ class WatermarkOverlayView: UIView {
         let maxWidth = max(bounds.width - 2 * inset, 0)
         let size = label.sizeThatFits(CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
         let horizontalSpan = max(bounds.width - size.width - 2 * inset, 0)
-        let x = inset + horizontalSpan * CGFloat(config.x) / 100
+        let isPingPongAnimation = config.animation?.type == .pingPong
+        let x = isPingPongAnimation ? inset : inset + horizontalSpan * CGFloat(config.x) / 100
 
         let top = inset
         let bottomLimit: CGFloat
@@ -91,6 +125,48 @@ class WatermarkOverlayView: UIView {
         }
         let y = top + (bottomLimit - top) * CGFloat(config.y) / 100
         return CGRect(origin: CGPoint(x: x, y: y), size: size)
+    }
+
+    private func restartAnimationIfSpanChanged(_ animation: WatermarkAnimation, on label: UILabel) {
+        let span = max(bounds.width - label.frame.width - 2 * inset, 0)
+        let labelID = ObjectIdentifier(label)
+        // Rebuild if the travel distance changed, or if the animation was dropped
+        // (e.g. when the view is detached from the window during a fullscreen transition).
+        let hasAnimation = label.layer.animation(forKey: Self.animationKey) != nil
+        guard watermarkSpans[labelID] != span || !hasAnimation else { return }
+        watermarkSpans[labelID] = span
+        label.layer.transform = CATransform3DIdentity
+        label.layer.removeAllAnimations()
+        label.layer.add(makeAnimation(for: animation, span: span), forKey: Self.animationKey)
+    }
+
+    private func pauseLayer(_ layer: CALayer) {
+        let pausedTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+        layer.speed = 0
+        layer.timeOffset = pausedTime
+    }
+
+    private func resumeLayer(_ layer: CALayer) {
+        layer.speed = 1
+        layer.timeOffset = 0
+        layer.beginTime = 0
+    }
+
+    private func makeAnimation(for animation: WatermarkAnimation, span: CGFloat) -> CAAnimation {
+        switch animation.type {
+        case .pingPong:
+            return makePingPongAnimation(span: span, duration: animation.duration)
+        }
+    }
+
+    private func makePingPongAnimation(span: CGFloat, duration: Int64) -> CAKeyframeAnimation {
+        let keyframe = CAKeyframeAnimation(keyPath: "transform.translation.x")
+        keyframe.values = [0, span]
+        keyframe.keyTimes = [0, 1]
+        keyframe.duration = Double(duration) / 1000
+        keyframe.autoreverses = true
+        keyframe.repeatCount = .infinity
+        return keyframe
     }
 
     private func color(for config: WatermarkConfig) -> UIColor {
@@ -107,13 +183,25 @@ class WatermarkOverlayView: UIView {
 struct WatermarkOverlayViewRepresentable: UIViewRepresentable {
     let watermarks: [WatermarkConfig]
     let reservedBottomHeight: CGFloat
+    let labelsAreFrozen: Bool
 
     func makeUIView(context: Context) -> WatermarkOverlayView {
-        WatermarkOverlayView(frame: .zero)
+        let view = WatermarkOverlayView(frame: .zero)
+        view.setWatermarks(watermarks)
+        view.setReservedBottomHeight(reservedBottomHeight)
+        if labelsAreFrozen {
+            view.pauseWatermarks()
+        }
+        return view
     }
 
     func updateUIView(_ uiView: WatermarkOverlayView, context: Context) {
         uiView.setWatermarks(watermarks)
         uiView.setReservedBottomHeight(reservedBottomHeight)
+        if labelsAreFrozen {
+            uiView.pauseWatermarks()
+        } else {
+            uiView.resumeWatermarks()
+        }
     }
 }

--- a/StoryboardExample/MainViewController.swift
+++ b/StoryboardExample/MainViewController.swift
@@ -40,7 +40,7 @@ class MainViewController: UIViewController {
     }
     
     @IBAction func sample1Tapped(_ sender: UIButton) {
-        presentPlayerViewController(assistId: "Bdf3fAyEQGS", accessToken: "ddd59961-9247-4f25-a877-63c0fbd392fe")
+        presentPlayerViewController(assistId: "7xbZeQzR36h", accessToken: "3d9838f3-db51-4fc3-8472-075ab5e40b64")
     }
     
     @IBAction func sample2Tapped(_ sender: UIButton) {

--- a/openspec/changes/add-watermark-support/tasks.md
+++ b/openspec/changes/add-watermark-support/tasks.md
@@ -16,10 +16,10 @@
 
 ## 3. Animation Support
 
-- [ ] 3.1 Implement pingPong animation with `CAKeyframeAnimation` on `transform.translation.x`, `autoreverses = true`, `repeatCount = .infinity`: one leg per configured duration, y constant, full-span traversal (x coordinate ignored while animating)
-- [ ] 3.2 Support independent animation per watermark layer
-- [ ] 3.3 Pause animations when playback is not active (paused, buffering, ended) and resume from the paused position when playback resumes; watermarks remain visible while paused. Playback state is observed by the presentation views (they already hold the player), not `TPAVPlayer`
-- [ ] 3.4 Preserve animation continuity on update via value equality: unchanged configs keep their layer/animation, changed configs are re-created
+- [x] 3.1 Implement pingPong animation with `CAKeyframeAnimation` on `transform.translation.x`, `autoreverses = true`, `repeatCount = .infinity`: one leg per configured duration, y constant, full-span traversal (x coordinate ignored while animating)
+- [x] 3.2 Support independent animation per watermark layer
+- [x] 3.3 Pause animations when playback is not active (paused, buffering, ended) and resume from the paused position when playback resumes; watermarks remain visible while paused. Playback state is observed by the presentation views (they already hold the player), not `TPAVPlayer`
+- [x] 3.4 Preserve animation continuity on update via value equality: unchanged configs keep their layer/animation, changed configs are re-created
 
 ## 4. Player Lifecycle Integration
 


### PR DESCRIPTION
Add the pingPong animation path to the watermark overlay, matching the Flutter/Android contract:

- Animate each watermark independently with a CAKeyframeAnimation on transform.translation.x (autoreverses + infinite repeat, one leg per configured duration). Animated watermarks sweep the full available span, hold their y position, and ignore the x coordinate.
- Pause/resume with playback state, observed by the presentation views: UIKit observes player.timeControlStatus, SwiftUI observes observedStatus. Paused watermarks keep their position and resume from the same progress; progress is remapped to the new span on layout changes, so watermarks reposition correctly through rotation and fullscreen instead of freezing at the old offset.
- Preserve continuity across config updates: unchanged watermark configs keep their label and running animation, changed ones are re-created.
- Floor animation duration at 100 ms during normalization.

Closes the animated watermark tasks in openspec change add-watermark-support.