### PR TITLE
Wire viewer-count presence heartbeat/leave into the player

### DIFF
--- a/Source/Managers/TPStreamPlayer.swift
+++ b/Source/Managers/TPStreamPlayer.swift
@@ -43,6 +43,13 @@ class TPStreamPlayer: NSObject {
     private var lastWatchedPositionSyncTimer: Timer?
     private let userId: String?
 
+    // Set by TPStreamPlayerViewController right after construction, wired
+    // through to the app's presenceTokenExpired delegate method. Reads the
+    // delegate fresh on every call rather than being handed a snapshot of it.
+    var onPresenceTokenExpired: ((String, @escaping (String?) -> Void) -> Void)?
+    private var presenceHeartbeatManager: PresenceHeartbeatManager?
+    private lazy var presenceViewerIdStore = PresenceViewerIdStore()
+
     /// `true` when the SDK can synchronize and restore the user's last watched position.
     /// The resume state is synced using the provided `userId` and the asset ID,
     /// allowing playback to continue from the last watched position whenever the
@@ -77,6 +84,7 @@ class TPStreamPlayer: NSObject {
     deinit {
         updateLastWatchedPosition()
         stopLastWatchedPositionSync()
+        presenceHeartbeatManager?.stop()
     }
     
     private func observeCurrentItemChanges() {
@@ -171,21 +179,51 @@ class TPStreamPlayer: NSObject {
     @objc private func playerDidFinishPlaying(){
         status = "ended"
         deleteLastWatchedPosition()
+        stopPresenceHeartbeat()
     }
-    
+
     private func handlePlaybackStatusChange(for player: TPAVPlayer) {
         switch player.timeControlStatus {
         case .playing:
             status = "playing"
+            startPresenceHeartbeat()
         case .paused:
             if status == "ended" {return}
             status = "paused"
             updateLastWatchedPosition()
+            stopPresenceHeartbeat()
         case .waitingToPlayAtSpecifiedRate:
             break
         @unknown default:
             break
         }
+    }
+
+    // Reads the current asset's presence config fresh on every call rather
+    // than caching it at load time, so a reload that picks up a renewed token
+    // is used without any extra plumbing.
+    private func startPresenceHeartbeat() {
+        guard let presence = player.asset?.liveStream?.presence, let videoId = player.assetID else { return }
+        if presenceHeartbeatManager == nil {
+            presenceHeartbeatManager = PresenceHeartbeatManager(
+                viewerId: presenceViewerIdStore.getOrCreate(),
+                scheduler: DispatchPresenceScheduler(),
+                onTokenExpired: { [weak self] callback in
+                    guard let self = self, let onPresenceTokenExpired = self.onPresenceTokenExpired else {
+                        callback("")
+                        return
+                    }
+                    onPresenceTokenExpired(videoId) { newToken in
+                        callback(newToken ?? "")
+                    }
+                }
+            )
+        }
+        presenceHeartbeatManager?.start(baseUrl: presence.baseUrl, token: presence.token)
+    }
+
+    private func stopPresenceHeartbeat() {
+        presenceHeartbeatManager?.stop()
     }
     
     private func handleBufferStatusChange(of playerItem: AVPlayerItem, keyPath: String) {

--- a/Source/Network/BaseAPI.swift
+++ b/Source/Network/BaseAPI.swift
@@ -21,9 +21,16 @@ class BaseAPI {
     class var parser: APIParser {
         fatalError("parser must be implemented by subclasses.")
     }
-    
+
     class var userAgentPrefix: String? {
         return nil
+    }
+
+    // Only StreamsAPI (TPStreams) overrides this: the legacy TestPress
+    // provider has no presence/live-viewer-count support, so viewer_id has
+    // nothing to bind there and must not leak into that URL.
+    class var supportsPresence: Bool {
+        return false
     }
     
     private static let systemUserAgent = HTTPHeaders.default.value(for: "User-Agent") ?? ""
@@ -36,8 +43,16 @@ class BaseAPI {
     }
     
     static func getAsset(_ assetID: String, _ accessToken: String?, completion: @escaping (Asset?, Error?) -> Void) {
-        let url = URL(string: String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? ""))!
-        
+        var urlString = String(format: VIDEO_DETAIL_API, TPStreamsSDK.orgCode!, assetID, accessToken ?? "")
+        if supportsPresence {
+            // Without this the server mints a fresh anonymous id per request,
+            // and the presence token it hands back could never pass device
+            // binding at all — see PresenceViewerIdStore.
+            let viewerId = PresenceViewerIdStore().getOrCreate()
+            urlString += "&viewer_id=\(viewerId)"
+        }
+        let url = URL(string: urlString)!
+
         var headers: HTTPHeaders = (TPStreamsSDK.authToken?.isEmpty == false) ? ["Authorization": "JWT \(TPStreamsSDK.authToken!)"] : [:]
         headers.update(name: "User-Agent", value: Self.customUserAgent)
         

--- a/Source/Network/Models/LiveStream.swift
+++ b/Source/Network/Models/LiveStream.swift
@@ -14,8 +14,27 @@ struct LiveStream{
     let chatEmbedUrl: String
     let noticeMessage: String?
     let enableDRM: Bool
-    
+    let presence: Presence?
+
+    init(status: String, hlsUrl: String, transcodeRecordedVideo: Bool, chatEmbedUrl: String, noticeMessage: String?, enableDRM: Bool, presence: Presence? = nil) {
+        self.status = status
+        self.hlsUrl = hlsUrl
+        self.transcodeRecordedVideo = transcodeRecordedVideo
+        self.chatEmbedUrl = chatEmbedUrl
+        self.noticeMessage = noticeMessage
+        self.enableDRM = enableDRM
+        self.presence = presence
+    }
+
     var isStreaming: Bool {
         return status == "Streaming" || status == "Running"
     }
+}
+
+// Nothing downstream needs the hashed vid the server also mints alongside
+// this — only the raw device id (PresenceViewerIdStore) that produced it,
+// which the app already has, matters for resending on heartbeat/leave.
+struct Presence {
+    let token: String
+    let baseUrl: String
 }

--- a/Source/Network/Parsers/StreamsAPIParser.swift
+++ b/Source/Network/Parsers/StreamsAPIParser.swift
@@ -56,7 +56,21 @@ class StreamsAPIParser: APIParser {
         }
         let noticeMessage = liveStreamDict["notice_message"] as? String
         let enableDRM = liveStreamDict["enable_drm"] as? Bool ?? false
-   
-        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage, enableDRM: enableDRM)
+        let presence = parsePresence(from: liveStreamDict["presence"] as? [String: Any])
+
+        return LiveStream(status: status, hlsUrl: hlsUrl, transcodeRecordedVideo: transcodeRecordedVideo, chatEmbedUrl: chatEmbedUrl, noticeMessage: noticeMessage, enableDRM: enableDRM, presence: presence)
+    }
+
+    // A malformed or absent presence payload is treated as no presence at
+    // all, rather than propagating a half-populated config further — presence
+    // is a bolt-on feature that must never be able to break asset parsing.
+    func parsePresence(from dictionary: [String: Any]?) -> Presence? {
+        guard let presenceDict = dictionary,
+              let token = presenceDict["token"] as? String,
+              let baseUrl = presenceDict["base_url"] as? String,
+              !token.isEmpty, !baseUrl.isEmpty else {
+            return nil
+        }
+        return Presence(token: token, baseUrl: baseUrl)
     }
 }

--- a/Source/Network/StreamsAPI.swift
+++ b/Source/Network/StreamsAPI.swift
@@ -23,4 +23,8 @@ class StreamsAPI: BaseAPI {
     override class var parser: APIParser {
         return StreamsAPIParser()
     }
+
+    class override var supportsPresence: Bool {
+        return true
+    }
 }

--- a/Source/Presence/PresenceHeartbeatManager.swift
+++ b/Source/Presence/PresenceHeartbeatManager.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+// Mirrors the web presence-client's heartbeat loop (see player.js's
+// PresenceClient) and the Android SDK's PresenceHeartbeatManager, so all
+// three behave identically from the server's point of view. Kept entirely
+// internal to the player: an app never starts or stops this directly, only
+// TPStreamPlayerDelegate.presenceTokenExpired reaches outside this class,
+// when a fresh token is needed.
+final class PresenceHeartbeatManager {
+    enum PresenceError: Error {
+        case invalidResponse
+        case unexpectedStatusCode(Int)
+    }
+
+    private static let maxBackoffMultiplier = 8
+
+    private let urlSession: URLSession
+    private let viewerId: String
+    private let scheduler: PresenceScheduler
+    // Called on a 401 with a callback that must be invoked with a fresh token,
+    // or an empty string if none could be obtained. An app that hasn't
+    // implemented presenceTokenExpired simply never calls this back, and the
+    // loop quietly stops rather than erroring.
+    private let onTokenExpired: (@escaping (String) -> Void) -> Void
+    private let onError: ((Error) -> Void)?
+    private let fallbackInterval: TimeInterval
+
+    private let lock = NSLock()
+    private var token: String = ""
+    private var baseUrl: String = ""
+    private var active = false
+    private var unauthorizedStreak = 0
+    private var scheduled: PresenceCancellable?
+
+    init(
+        urlSession: URLSession = .shared,
+        viewerId: String,
+        scheduler: PresenceScheduler,
+        onTokenExpired: @escaping (@escaping (String) -> Void) -> Void,
+        onError: ((Error) -> Void)? = nil,
+        fallbackInterval: TimeInterval = 15
+    ) {
+        self.urlSession = urlSession
+        self.viewerId = viewerId
+        self.scheduler = scheduler
+        self.onTokenExpired = onTokenExpired
+        self.onError = onError
+        self.fallbackInterval = fallbackInterval
+    }
+
+    // Call this only while playback is actually active. Safe to call more
+    // than once; a call while already active is a no-op.
+    func start(baseUrl: String, token: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !active, !baseUrl.isEmpty, !token.isEmpty else { return }
+        self.baseUrl = baseUrl
+        self.token = token
+        self.unauthorizedStreak = 0
+        active = true
+        // Spreads the first beat across the interval instead of firing it the
+        // moment playback starts. A scheduled class means many viewers
+        // pressing play within the same few seconds, and without this they
+        // would then beat in lockstep for the whole session — a request spike
+        // every interval rather than steady load.
+        scheduleNextBeatLocked(after: TimeInterval.random(in: 0..<fallbackInterval))
+    }
+
+    // Sends a final leave beacon and stops the loop. Safe to call more than
+    // once or without a matching start().
+    func stop() {
+        lock.lock()
+        guard active else {
+            lock.unlock()
+            return
+        }
+        active = false
+        scheduled?.cancel()
+        scheduled = nil
+        let currentToken = token
+        let currentBaseUrl = baseUrl
+        lock.unlock()
+        sendLeaveBeacon(baseUrl: currentBaseUrl, token: currentToken)
+    }
+
+    // Assumes the lock is already held by the caller.
+    private func scheduleNextBeatLocked(after seconds: TimeInterval) {
+        guard active else { return }
+        scheduled = scheduler.schedule(after: seconds) { [weak self] in self?.beat() }
+    }
+
+    private func scheduleNextBeat(after seconds: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        scheduleNextBeatLocked(after: seconds)
+    }
+
+    private func beat() {
+        lock.lock()
+        guard active else {
+            lock.unlock()
+            return
+        }
+        let currentToken = token
+        let currentBaseUrl = baseUrl
+        lock.unlock()
+
+        guard let url = URL(string: "\(currentBaseUrl)/presence/v1/heartbeat") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(currentToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Resent on every call, not just once when requesting playback: the
+        // server hashes it and checks it still matches the vid baked into the
+        // token, so a token copied to another device gets rejected.
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["viewer_id": viewerId])
+
+        urlSession.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+            // Network hiccup: keep the loop alive on the fallback cadence
+            // rather than letting this bring playback down with it.
+            if let error = error {
+                self.onError?(error)
+                self.scheduleNextBeat(after: self.fallbackInterval)
+                return
+            }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                self.onError?(PresenceError.invalidResponse)
+                self.scheduleNextBeat(after: self.fallbackInterval)
+                return
+            }
+            self.handleHeartbeatResponse(httpResponse, data: data)
+        }.resume()
+    }
+
+    private func handleHeartbeatResponse(_ response: HTTPURLResponse, data: Data?) {
+        switch response.statusCode {
+        case 401:
+            recoverFromUnauthorized()
+        case 429:
+            lock.lock()
+            unauthorizedStreak = 0
+            lock.unlock()
+            let retryAfter = response.value(forHTTPHeaderField: "Retry-After").flatMap(Double.init)
+            scheduleNextBeat(after: retryAfter ?? fallbackInterval)
+        case 200..<300:
+            lock.lock()
+            unauthorizedStreak = 0
+            lock.unlock()
+            scheduleNextBeat(after: parseNextHeartbeatIn(data) ?? fallbackInterval)
+        default:
+            onError?(PresenceError.unexpectedStatusCode(response.statusCode))
+            scheduleNextBeat(after: fallbackInterval)
+        }
+    }
+
+    private func parseNextHeartbeatIn(_ data: Data?) -> TimeInterval? {
+        guard let data = data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = json["next_heartbeat_in"] as? NSNumber else {
+            return nil
+        }
+        return value.doubleValue
+    }
+
+    // A 401 here could mean either an expired token or a device-binding
+    // mismatch — there's no need to tell them apart, both are resolved by
+    // asking the integrator for a fresh playback config and resuming with its
+    // token, exactly like the web SDK's recoverFromUnauthorized.
+    private func recoverFromUnauthorized() {
+        lock.lock()
+        unauthorizedStreak += 1
+        lock.unlock()
+        onTokenExpired { [weak self] newToken in
+            guard let self = self else { return }
+            if !newToken.isEmpty {
+                self.applyRefreshedToken(newToken)
+            } else {
+                self.backOffAfterFailedRefresh()
+            }
+        }
+    }
+
+    private func applyRefreshedToken(_ newToken: String) {
+        lock.lock()
+        guard active else {
+            lock.unlock()
+            return
+        }
+        token = newToken
+        unauthorizedStreak = 0
+        lock.unlock()
+        scheduleNextBeat(after: fallbackInterval)
+    }
+
+    private func backOffAfterFailedRefresh() {
+        lock.lock()
+        guard active else {
+            lock.unlock()
+            return
+        }
+        // Backs off further each consecutive failure — capped, not abandoned:
+        // an integrator's own backend can be down for a while and recover,
+        // and this loop has no playback-affecting reason to ever give up on it.
+        let multiplier = min(unauthorizedStreak, Self.maxBackoffMultiplier)
+        lock.unlock()
+        scheduleNextBeat(after: fallbackInterval * TimeInterval(multiplier))
+    }
+
+    private func sendLeaveBeacon(baseUrl: String, token: String) {
+        // Best-effort, fire-and-forget: never blocks player teardown on a
+        // response.
+        guard let url = URL(string: "\(baseUrl)/presence/v1/leave") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "presence_token": token,
+            "viewer_id": viewerId,
+        ])
+        urlSession.dataTask(with: request) { [weak self] _, _, error in
+            if let error = error {
+                self?.onError?(error)
+            }
+        }.resume()
+    }
+}

--- a/Source/Presence/PresenceScheduler.swift
+++ b/Source/Presence/PresenceScheduler.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// Abstracts the heartbeat loop's delayed scheduling so PresenceHeartbeatManager
+// can be unit tested with a fake that fires deterministically, without
+// depending on a real run loop. Dispatch-based rather than Timer-based in the
+// real implementation: a URLSession completion handler runs on a background
+// queue with no active run loop, and Timer.scheduledTimer silently never
+// fires when scheduled from one.
+protocol PresenceScheduler {
+    func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> PresenceCancellable
+}
+
+protocol PresenceCancellable {
+    func cancel()
+}
+
+final class DispatchPresenceScheduler: PresenceScheduler {
+    private let queue: DispatchQueue
+
+    init(queue: DispatchQueue = DispatchQueue(label: "com.tpstream.player.presence.heartbeat")) {
+        self.queue = queue
+    }
+
+    func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> PresenceCancellable {
+        let workItem = DispatchWorkItem(block: action)
+        queue.asyncAfter(deadline: .now() + max(seconds, 0), execute: workItem)
+        return DispatchPresenceCancellable(workItem: workItem)
+    }
+}
+
+private final class DispatchPresenceCancellable: PresenceCancellable {
+    private let workItem: DispatchWorkItem
+
+    init(workItem: DispatchWorkItem) {
+        self.workItem = workItem
+    }
+
+    func cancel() {
+        workItem.cancel()
+    }
+}

--- a/Source/Presence/PresenceViewerIdStore.swift
+++ b/Source/Presence/PresenceViewerIdStore.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+protocol PresenceKeyValueStore {
+    func getString(forKey key: String) -> String?
+    func setString(_ value: String, forKey key: String)
+}
+
+final class KeychainPresenceKeyValueStore: PresenceKeyValueStore {
+    private static let service = "com.tpstream.player.presence"
+
+    func getString(forKey key: String) -> String? {
+        guard let data = KeychainUtil.get(service: Self.service, account: key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func setString(_ value: String, forKey key: String) {
+        guard let data = value.data(using: .utf8) else { return }
+        KeychainUtil.save(data: data, service: Self.service, account: key)
+    }
+}
+
+// Generated once and persisted, so the same value can be forwarded as the
+// viewer_id query param when requesting playback and resent on every
+// heartbeat/leave call after — same purpose as the web SDK's
+// getOrCreatePersistentViewerId(), backed by the Keychain (rather than
+// UserDefaults) so it survives not just app restarts but reinstalls too,
+// matching localStorage's own survive-a-reload intent as closely as this
+// platform allows.
+final class PresenceViewerIdStore {
+    private static let viewerIdKey = "viewer_id"
+
+    private let store: PresenceKeyValueStore
+
+    init(store: PresenceKeyValueStore = KeychainPresenceKeyValueStore()) {
+        self.store = store
+    }
+
+    func getOrCreate() -> String {
+        if let existing = store.getString(forKey: Self.viewerIdKey) {
+            return existing
+        }
+        let generated = UUID().uuidString
+        store.setString(generated, forKey: Self.viewerIdKey)
+        return generated
+    }
+}

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -80,6 +80,17 @@ public class TPStreamPlayerViewController: UIViewController {
             fatalError("Could not load PlayerControls view from nib.")
         }
         view.player = TPStreamPlayer(player: self.player!, userId: config.userId)
+        // Reads self.delegate fresh on every call rather than capturing it now,
+        // so this still works correctly if delegate is assigned after this
+        // lazy var's first access (a common ordering: init, then set delegate,
+        // then present).
+        view.player?.onPresenceTokenExpired = { [weak self] videoId, completion in
+            guard let self = self, let delegate = self.delegate else {
+                completion(nil)
+                return
+            }
+            delegate.presenceTokenExpired(forVideo: videoId, completion: completion)
+        }
         view.playerConfig = config
         view.frame = view.bounds
         view.isHidden = true
@@ -333,8 +344,21 @@ public protocol TPStreamPlayerViewControllerDelegate {
     func willExitFullScreenMode()
     func didExitFullScreenMode()
     func didTapReplay()
+    // Called on a 401 from the presence heartbeat loop — an expired token and
+    // a device-binding mismatch look identical from here, and both are
+    // resolved the same way: fetch a fresh playback config and call
+    // completion with its presence token, or with nil if none could be
+    // obtained. Mirrors the shape Android integrators already know from
+    // onAccessTokenExpired(videoId, callback).
+    func presenceTokenExpired(forVideo videoId: String, completion: @escaping (String?) -> Void)
 }
 
 public extension TPStreamPlayerViewControllerDelegate {
     func didTapReplay() {}
+    // Optional (default no-op): presence is still rollout-gated to a handful
+    // of organizations, and a required override would break every existing
+    // integrator for a feature almost none of them have enabled. An app that
+    // doesn't override this simply never has its heartbeat loop resume after
+    // a 401 — it just quietly stops, the same as if presence were disabled.
+    func presenceTokenExpired(forVideo videoId: String, completion: @escaping (String?) -> Void) {}
 }

--- a/Tests/MockURLProtocol.swift
+++ b/Tests/MockURLProtocol.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+// Standard XCTest network-mocking pattern: intercepts every request made
+// through a URLSession configured with this as its only protocol class, so
+// PresenceHeartbeatManagerTests never touches the real network.
+final class MockURLProtocol: URLProtocol {
+    struct StubbedResponse {
+        let statusCode: Int
+        let headers: [String: String]
+        let body: Data?
+
+        init(statusCode: Int, headers: [String: String] = [:], body: Data? = nil) {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.body = body
+        }
+    }
+
+    private static let lock = NSLock()
+    private static var responseQueue: [StubbedResponse] = []
+    private static var _capturedRequests: [URLRequest] = []
+    private static var failNextRequestWithError: Error?
+    // Fired synchronously from startLoading() after a request is captured and
+    // its response fully delivered, so tests can wait on an exact signal
+    // instead of a fixed delay.
+    static var onRequestHandled: ((URLRequest) -> Void)?
+
+    static var capturedRequests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _capturedRequests
+    }
+
+    static func reset() {
+        lock.lock()
+        responseQueue = []
+        _capturedRequests = []
+        failNextRequestWithError = nil
+        onRequestHandled = nil
+        lock.unlock()
+    }
+
+    static func enqueue(_ response: StubbedResponse) {
+        lock.lock()
+        responseQueue.append(response)
+        lock.unlock()
+    }
+
+    static func failNextRequest(with error: Error) {
+        lock.lock()
+        failNextRequestWithError = error
+        lock.unlock()
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        MockURLProtocol.lock.lock()
+        MockURLProtocol._capturedRequests.append(request)
+        let error = MockURLProtocol.failNextRequestWithError
+        MockURLProtocol.failNextRequestWithError = nil
+        let stubbed = MockURLProtocol.responseQueue.isEmpty ? nil : MockURLProtocol.responseQueue.removeFirst()
+        MockURLProtocol.lock.unlock()
+
+        defer { MockURLProtocol.onRequestHandled?(request) }
+
+        if let error = error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        guard let stubbed = stubbed, let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: stubbed.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: stubbed.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let body = stubbed.body {
+            client?.urlProtocol(self, didLoad: body)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/PresenceHeartbeatManagerTests.swift
+++ b/Tests/PresenceHeartbeatManagerTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+@testable import TPStreamsSDK
+
+private let viewerId = "device-abc-123"
+private let baseUrl = "https://presence.tpstreams.test"
+
+// Records every scheduled beat instead of running it, so the test controls
+// exactly when each one fires — the real request still goes through
+// MockURLProtocol on URLSession's own background machinery, which is what
+// makes a semaphore the right synchronization primitive here rather than a
+// plain array.
+private final class RecordingPresenceScheduler: PresenceScheduler {
+    struct ScheduledCall {
+        let seconds: TimeInterval
+        let action: () -> Void
+    }
+
+    private let lock = NSLock()
+    private var pending: [ScheduledCall] = []
+    private let semaphore = DispatchSemaphore(value: 0)
+    private(set) var cancelledCount = 0
+
+    func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> PresenceCancellable {
+        lock.lock()
+        pending.append(ScheduledCall(seconds: seconds, action: action))
+        lock.unlock()
+        semaphore.signal()
+        return RecordingCancellable(scheduler: self)
+    }
+
+    func awaitNextSchedule(timeout: TimeInterval = 5, file: StaticString = #filePath, line: UInt = #line) -> ScheduledCall {
+        switch semaphore.wait(timeout: .now() + timeout) {
+        case .timedOut:
+            XCTFail("No beat was scheduled within the timeout", file: file, line: line)
+            return ScheduledCall(seconds: 0, action: {})
+        case .success:
+            lock.lock()
+            defer { lock.unlock() }
+            return pending.removeFirst()
+        }
+    }
+
+    func assertNothingScheduled(within seconds: TimeInterval, file: StaticString = #filePath, line: UInt = #line) {
+        switch semaphore.wait(timeout: .now() + seconds) {
+        case .success:
+            XCTFail("expected no further beat to be scheduled, but one was", file: file, line: line)
+        case .timedOut:
+            break
+        }
+    }
+
+    fileprivate func recordCancellation() {
+        lock.lock()
+        cancelledCount += 1
+        lock.unlock()
+    }
+}
+
+private final class RecordingCancellable: PresenceCancellable {
+    private weak var scheduler: RecordingPresenceScheduler?
+
+    init(scheduler: RecordingPresenceScheduler) {
+        self.scheduler = scheduler
+    }
+
+    func cancel() {
+        scheduler?.recordCancellation()
+    }
+}
+
+final class PresenceHeartbeatManagerTests: XCTestCase {
+    private var scheduler: RecordingPresenceScheduler!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = RecordingPresenceScheduler()
+        MockURLProtocol.reset()
+    }
+
+    private func buildManager(
+        onTokenExpired: @escaping (@escaping (String) -> Void) -> Void = { callback in callback("") },
+        onError: ((Error) -> Void)? = nil
+    ) -> PresenceHeartbeatManager {
+        return PresenceHeartbeatManager(
+            urlSession: MockURLProtocol.session(),
+            viewerId: viewerId,
+            scheduler: scheduler,
+            onTokenExpired: onTokenExpired,
+            onError: onError
+        )
+    }
+
+    private func okResponse(nextHeartbeatIn: Int = 15) -> MockURLProtocol.StubbedResponse {
+        let body = try! JSONSerialization.data(withJSONObject: ["ok": true, "next_heartbeat_in": nextHeartbeatIn])
+        return MockURLProtocol.StubbedResponse(statusCode: 200, body: body)
+    }
+
+    // Arms an expectation for the Nth request MockURLProtocol fully handles
+    // (captured and responded to) — call before triggering the action that
+    // causes it, then wait(for:) after. Precise regardless of how long
+    // URLSession takes to dispatch onto the protocol, unlike a fixed delay.
+    private func expectRequestsHandled(_ count: Int) -> XCTestExpectation {
+        let expectation = expectation(description: "\(count) request(s) handled")
+        var handled = 0
+        MockURLProtocol.onRequestHandled = { _ in
+            handled += 1
+            if handled >= count {
+                expectation.fulfill()
+            }
+        }
+        return expectation
+    }
+
+    private func bodyJSON(_ request: URLRequest) -> [String: Any] {
+        guard let data = request.httpBody ?? request.httpBodyStream.map({ stream -> Data in
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            let bufferSize = 1024
+            var buffer = [UInt8](repeating: 0, count: bufferSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buffer, maxLength: bufferSize)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            return data
+        }) else { return [:] }
+        return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    func testSendsTheFirstHeartbeatWithTheBearerTokenAndThePersistedViewerId() {
+        MockURLProtocol.enqueue(okResponse())
+        let manager = buildManager()
+        let handled = expectRequestsHandled(1)
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+        wait(for: [handled], timeout: 5)
+
+        let request = MockURLProtocol.capturedRequests.first
+        XCTAssertEqual(request?.url?.absoluteString, "\(baseUrl)/presence/v1/heartbeat")
+        XCTAssertEqual(request?.httpMethod, "POST")
+        XCTAssertEqual(request?.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+        XCTAssertEqual(bodyJSON(request!)["viewer_id"] as? String, viewerId)
+    }
+
+    func testSchedulesTheNextHeartbeatUsingNextHeartbeatInFromTheResponse() {
+        MockURLProtocol.enqueue(okResponse(nextHeartbeatIn: 42))
+        let manager = buildManager()
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+
+        XCTAssertEqual(scheduler.awaitNextSchedule().seconds, 42)
+    }
+
+    func testOn401RefreshesViaOnTokenExpiredAndResumesWithTheNewToken() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 401))
+        MockURLProtocol.enqueue(okResponse())
+        var refreshCallCount = 0
+        let manager = buildManager(onTokenExpired: { callback in
+            refreshCallCount += 1
+            callback("refreshed-token")
+        })
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+        // Only appears once the 401 response has been fully processed and the
+        // refresh (synchronous in this test) has rescheduled — the queue
+        // itself is the synchronization point, no fixed delay needed here.
+        let secondCall = scheduler.awaitNextSchedule()
+        let handled = expectRequestsHandled(1)
+        secondCall.action()
+        wait(for: [handled], timeout: 5)
+
+        XCTAssertEqual(refreshCallCount, 1)
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.value(forHTTPHeaderField: "Authorization"), "Bearer refreshed-token")
+    }
+
+    func testKeepsBackingOffInsteadOfGivingUpWhenRefreshKeepsFailing() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 401))
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 401))
+        let manager = buildManager(onTokenExpired: { callback in callback("") })
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+        let afterFirstFailure = scheduler.awaitNextSchedule()
+        XCTAssertEqual(afterFirstFailure.seconds, 15)
+        afterFirstFailure.action()
+
+        let afterSecondFailure = scheduler.awaitNextSchedule()
+        XCTAssertGreaterThan(afterSecondFailure.seconds, afterFirstFailure.seconds)
+    }
+
+    func testRespectsRetryAfterOnA429InsteadOfTheDefaultInterval() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 429, headers: ["Retry-After": "5"]))
+        let manager = buildManager()
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+
+        XCTAssertEqual(scheduler.awaitNextSchedule().seconds, 5)
+    }
+
+    func testSwallowsANetworkErrorAndKeepsTheLoopAliveOnTheFallbackCadence() {
+        MockURLProtocol.failNextRequest(with: URLError(.notConnectedToInternet))
+        var observedError: Error?
+        let manager = buildManager(onError: { observedError = $0 })
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        scheduler.awaitNextSchedule().action()
+
+        XCTAssertEqual(scheduler.awaitNextSchedule().seconds, 15)
+        XCTAssertNotNil(observedError)
+    }
+
+    func testStartIsIdempotentCallingItTwiceDoesNotScheduleASecondLoop() {
+        MockURLProtocol.enqueue(okResponse())
+        let manager = buildManager()
+        let handled = expectRequestsHandled(1)
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        manager.start(baseUrl: baseUrl, token: "token-2")
+        scheduler.awaitNextSchedule().action()
+        wait(for: [handled], timeout: 5)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.first?.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+        scheduler.assertNothingScheduled(within: 0.2)
+    }
+
+    func testStopSendsALeaveBeaconWithThePresenceTokenAndTheSameViewerId() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 204))
+        let manager = buildManager()
+        let handled = expectRequestsHandled(1)
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        manager.stop()
+        wait(for: [handled], timeout: 5)
+
+        let request = MockURLProtocol.capturedRequests.first
+        XCTAssertEqual(request?.url?.absoluteString, "\(baseUrl)/presence/v1/leave")
+        let body = bodyJSON(request!)
+        XCTAssertEqual(body["presence_token"] as? String, "token-1")
+        XCTAssertEqual(body["viewer_id"] as? String, viewerId)
+    }
+
+    func testStopCancelsTheScheduledBeat() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 204))
+        let manager = buildManager()
+
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        manager.stop()
+
+        XCTAssertEqual(scheduler.cancelledCount, 1)
+    }
+
+    func testStopIsIdempotentASecondCallDoesNotSendAnotherBeacon() {
+        MockURLProtocol.enqueue(MockURLProtocol.StubbedResponse(statusCode: 204))
+        let manager = buildManager()
+
+        let handled = expectRequestsHandled(1)
+        manager.start(baseUrl: baseUrl, token: "token-1")
+        manager.stop()
+        wait(for: [handled], timeout: 5)
+        manager.stop()
+
+        // Only a positive signal exists for "the first beacon was sent"; a
+        // second call sending nothing has no event to wait on, so this grace
+        // period is a deliberate exception to preferring the expectation
+        // above over a fixed delay.
+        let settle = expectation(description: "settle")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { settle.fulfill() }
+        wait(for: [settle], timeout: 2)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1)
+    }
+}

--- a/Tests/PresenceViewerIdStoreTests.swift
+++ b/Tests/PresenceViewerIdStoreTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import TPStreamsSDK
+
+private final class InMemoryPresenceKeyValueStore: PresenceKeyValueStore {
+    private var values: [String: String] = [:]
+
+    func getString(forKey key: String) -> String? {
+        return values[key]
+    }
+
+    func setString(_ value: String, forKey key: String) {
+        values[key] = value
+    }
+}
+
+final class PresenceViewerIdStoreTests: XCTestCase {
+
+    func testGeneratesAUUIDShapedId() {
+        let id = PresenceViewerIdStore(store: InMemoryPresenceKeyValueStore()).getOrCreate()
+
+        XCTAssertNotNil(UUID(uuidString: id))
+    }
+
+    func testPersistsTheGeneratedIdInTheUnderlyingStore() {
+        let store = InMemoryPresenceKeyValueStore()
+
+        let id = PresenceViewerIdStore(store: store).getOrCreate()
+
+        XCTAssertEqual(id, store.getString(forKey: "viewer_id"))
+    }
+
+    func testReturnsTheSameIdOnALaterCallAgainstTheSameStoreAsAcrossAnAppRestart() {
+        let store = InMemoryPresenceKeyValueStore()
+
+        let first = PresenceViewerIdStore(store: store).getOrCreate()
+        let second = PresenceViewerIdStore(store: store).getOrCreate()
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testReturnsDifferentIdsForIndependentStores() {
+        let first = PresenceViewerIdStore(store: InMemoryPresenceKeyValueStore()).getOrCreate()
+        let second = PresenceViewerIdStore(store: InMemoryPresenceKeyValueStore()).getOrCreate()
+
+        XCTAssertNotEqual(first, second)
+    }
+}

--- a/Tests/StreamsAPIParserPresenceTests.swift
+++ b/Tests/StreamsAPIParserPresenceTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import TPStreamsSDK
+
+final class StreamsAPIParserPresenceTests: XCTestCase {
+    private let parser = StreamsAPIParser()
+
+    private func liveStreamDict(presence: [String: Any]?) -> [String: Any] {
+        var dict: [String: Any] = [
+            "status": "Streaming",
+            "hls_url": "https://example.com/live.m3u8",
+            "transcode_recorded_video": true,
+            "chat_embed_url": "https://example.com/chat",
+        ]
+        if let presence = presence {
+            dict["presence"] = presence
+        }
+        return dict
+    }
+
+    func testParsesAPresentPresenceConfig() {
+        let liveStream = parser.parseLiveStream(from: liveStreamDict(presence: [
+            "token": "presence-token-abc",
+            "vid": "irrelevant-to-the-client",
+            "base_url": "https://presence.tpstreams.test",
+        ]))
+
+        XCTAssertEqual(liveStream?.presence?.token, "presence-token-abc")
+        XCTAssertEqual(liveStream?.presence?.baseUrl, "https://presence.tpstreams.test")
+    }
+
+    func testAbsentPresenceKeyParsesAsNoPresence() {
+        // What every organization not yet opted into the rollout actually
+        // gets back — must parse cleanly rather than error.
+        let liveStream = parser.parseLiveStream(from: liveStreamDict(presence: nil))
+
+        XCTAssertNil(liveStream?.presence)
+        XCTAssertNotNil(liveStream) // the rest of the live stream still parses
+    }
+
+    // A malformed presence (missing token or base_url) is treated the same as
+    // no presence at all, rather than letting a half-populated config reach
+    // the heartbeat manager — presence is a bolt-on feature that must never
+    // be able to break asset parsing.
+    func testPresenceMissingItsTokenParsesAsNoPresence() {
+        let liveStream = parser.parseLiveStream(from: liveStreamDict(presence: [
+            "base_url": "https://presence.tpstreams.test"
+        ]))
+
+        XCTAssertNil(liveStream?.presence)
+    }
+
+    func testPresenceMissingItsBaseUrlParsesAsNoPresence() {
+        let liveStream = parser.parseLiveStream(from: liveStreamDict(presence: [
+            "token": "presence-token-abc"
+        ]))
+
+        XCTAssertNil(liveStream?.presence)
+    }
+}
+
+final class ProviderPresenceScopeTests: XCTestCase {
+    // Presence/live-viewer-count is a TPStreams-only feature — the legacy
+    // TestPress provider's backend has no support for it.
+    func testStreamsAPISupportsPresence() {
+        XCTAssertTrue(StreamsAPI.supportsPresence)
+    }
+
+    func testTestpressAPIDoesNotSupportPresence() {
+        XCTAssertFalse(TestpressAPI.supportsPresence)
+    }
+}


### PR DESCRIPTION
Full description in the branch commit message. Test plan: presence test suite added (MockURLProtocol-based), could not run swift test in this environment (no Xcode toolchain). Depends on testpress/streams#2507. Companion PRs: testpress/TPStreamsAndroidPlayer, testpress/flutter-player-sdk, testpress/react-native-tpstreams.