### PR TITLE
fix: Anchor watermark to video content rect instead of full player view

### DIFF
--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -43,7 +43,7 @@ public struct TPStreamPlayerView: View {
                             ? SubtitleView.reservedBottomBandHeight
                             : 0,
                         labelsAreFrozen: playerObservable.observedStatus != "playing",
-                        videoRect: Self.calculateVideoRect(
+                        watermarkContentRect: Self.calculateVideoRect(
                             player: viewModel.player,
                             containerSize: CGSize(width: contentWidth, height: contentHeight)
                         )
@@ -105,40 +105,20 @@ public struct TPStreamPlayerView: View {
         }
     }
 
-    private static func calculateVideoRect(player: TPAVPlayer, containerSize: CGSize) -> CGRect {
-        guard containerSize.width > 0, containerSize.height > 0 else {
-            return .zero
-        }
-        guard let item = player.currentItem,
-              let track = item.asset.tracks(withMediaType: .video).first else {
-            return .zero
-        }
-        let naturalSize = track.naturalSize
-        let transform = track.preferredTransform
-        let transformedSize = naturalSize.applying(transform)
-        let displayedSize = CGSize(width: abs(transformedSize.width), height: abs(transformedSize.height))
+    private static func calculateVideoRect(
+        player: TPAVPlayer,
+        containerSize: CGSize
+    ) -> CGRect {
+        guard let videoSize = extractVideoSize(from: player) else { return .zero }
+        return VideoRectCalculator.calculate(videoSize: videoSize, containerSize: containerSize)
+    }
 
-        guard displayedSize.width > 0, displayedSize.height > 0 else { return .zero }
-
-        let videoAspect = displayedSize.width / displayedSize.height
-        let containerAspect = containerSize.width / containerSize.height
-
-        let renderedSize: CGSize
-        if videoAspect > containerAspect {
-            renderedSize = CGSize(
-                width: containerSize.width,
-                height: containerSize.width / videoAspect
-            )
-        } else {
-            renderedSize = CGSize(
-                width: containerSize.height * videoAspect,
-                height: containerSize.height
-            )
+    private static func extractVideoSize(from player: TPAVPlayer) -> CGSize? {
+        guard let track = player.currentItem?.asset.tracks(withMediaType: .video).first else {
+            return nil
         }
-        let origin = CGPoint(
-            x: (containerSize.width - renderedSize.width) / 2,
-            y: (containerSize.height - renderedSize.height) / 2
-        )
-        return CGRect(origin: origin, size: renderedSize)
+        let transformed = track.naturalSize.applying(track.preferredTransform)
+        let size = CGSize(width: abs(transformed.width), height: abs(transformed.height))
+        return (size.width > 0 && size.height > 0) ? size : nil
     }
 }

--- a/Source/TPStreamPlayerView.swift
+++ b/Source/TPStreamPlayerView.swift
@@ -22,6 +22,15 @@ public struct TPStreamPlayerView: View {
     
     public var body: some View {
         GeometryReader { geometry in
+            let isFullScreen = viewModel.isFullScreen
+            let horizontalPadding: CGFloat = isFullScreen ? 48 : 0
+            let contentWidth = (isFullScreen
+                ? UIScreen.main.fixedCoordinateSpace.bounds.height
+                : geometry.size.width) - horizontalPadding * 2
+            let contentHeight = isFullScreen
+                ? UIScreen.main.fixedCoordinateSpace.bounds.width
+                : geometry.size.height
+
             ZStack {
                 if let message = viewModel.noticeMessage {
                     NoticeView(message: message)
@@ -33,7 +42,11 @@ public struct TPStreamPlayerView: View {
                         reservedBottomHeight: playerViewConfig.enableCaptions && activeSubtitleTrack != nil
                             ? SubtitleView.reservedBottomBandHeight
                             : 0,
-                        labelsAreFrozen: playerObservable.observedStatus != "playing"
+                        labelsAreFrozen: playerObservable.observedStatus != "playing",
+                        videoRect: Self.calculateVideoRect(
+                            player: viewModel.player,
+                            containerSize: CGSize(width: contentWidth, height: contentHeight)
+                        )
                     )
                     
                     if playerViewConfig.enableCaptions, let activeSubtitleTrack = activeSubtitleTrack {
@@ -52,9 +65,9 @@ public struct TPStreamPlayerView: View {
                     .environmentObject(playerObservable)
                 }
             }
-            .padding(.horizontal, viewModel.isFullScreen ? 48 : 0)
-            .frame(width: viewModel.isFullScreen ? UIScreen.main.fixedCoordinateSpace.bounds.height : geometry.size.width,
-                   height: viewModel.isFullScreen ? UIScreen.main.fixedCoordinateSpace.bounds.width : geometry.size.height)
+            .padding(.horizontal, horizontalPadding)
+            .frame(width: contentWidth + horizontalPadding * 2,
+                   height: contentHeight)
             .background(Color.black)
             .edgesIgnoringSafeArea(viewModel.isFullScreen ? .all : [])
             .statusBarHidden(viewModel.isFullScreen)
@@ -90,5 +103,42 @@ public struct TPStreamPlayerView: View {
         } else {
             UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
         }
+    }
+
+    private static func calculateVideoRect(player: TPAVPlayer, containerSize: CGSize) -> CGRect {
+        guard containerSize.width > 0, containerSize.height > 0 else {
+            return .zero
+        }
+        guard let item = player.currentItem,
+              let track = item.asset.tracks(withMediaType: .video).first else {
+            return .zero
+        }
+        let naturalSize = track.naturalSize
+        let transform = track.preferredTransform
+        let transformedSize = naturalSize.applying(transform)
+        let displayedSize = CGSize(width: abs(transformedSize.width), height: abs(transformedSize.height))
+
+        guard displayedSize.width > 0, displayedSize.height > 0 else { return .zero }
+
+        let videoAspect = displayedSize.width / displayedSize.height
+        let containerAspect = containerSize.width / containerSize.height
+
+        let renderedSize: CGSize
+        if videoAspect > containerAspect {
+            renderedSize = CGSize(
+                width: containerSize.width,
+                height: containerSize.width / videoAspect
+            )
+        } else {
+            renderedSize = CGSize(
+                width: containerSize.height * videoAspect,
+                height: containerSize.height
+            )
+        }
+        let origin = CGPoint(
+            x: (containerSize.width - renderedSize.width) / 2,
+            y: (containerSize.height - renderedSize.height) / 2
+        )
+        return CGRect(origin: origin, size: renderedSize)
     }
 }

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -73,7 +73,7 @@ public class TPStreamPlayerViewController: UIViewController {
         view.backgroundColor = .black
         view.player = player
         view.onVideoRectChanged = { [weak self] rect in
-            self?.watermarkOverlayView.setVideoRect(rect)
+            self?.watermarkOverlayView.setWatermarkContentRect(rect)
         }
         return view
     }()
@@ -164,7 +164,7 @@ public class TPStreamPlayerViewController: UIViewController {
         videoView.frame = containerView.bounds
         subtitleView.frame = containerView.bounds
         watermarkOverlayView.frame = containerView.bounds
-        watermarkOverlayView.setVideoRect(videoView.videoRect)
+        watermarkOverlayView.setWatermarkContentRect(videoView.videoRect)
         watermarkOverlayView.setReservedBottomHeight(subtitleReservedHeight)
         controlsView.frame = containerView.bounds
         noticeView.frame = containerView.bounds

--- a/Source/TPStreamPlayerViewController.swift
+++ b/Source/TPStreamPlayerViewController.swift
@@ -72,6 +72,9 @@ public class TPStreamPlayerViewController: UIViewController {
         let view = TPVideoPlayerUIView(frame: view.frame)
         view.backgroundColor = .black
         view.player = player
+        view.onVideoRectChanged = { [weak self] rect in
+            self?.watermarkOverlayView.setVideoRect(rect)
+        }
         return view
     }()
     
@@ -153,10 +156,15 @@ public class TPStreamPlayerViewController: UIViewController {
     
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        layoutContainerSubviews()
+    }
+
+    private func layoutContainerSubviews() {
         containerView.frame = containerView.superview!.bounds
         videoView.frame = containerView.bounds
         subtitleView.frame = containerView.bounds
         watermarkOverlayView.frame = containerView.bounds
+        watermarkOverlayView.setVideoRect(videoView.videoRect)
         watermarkOverlayView.setReservedBottomHeight(subtitleReservedHeight)
         controlsView.frame = containerView.bounds
         noticeView.frame = containerView.bounds
@@ -302,6 +310,9 @@ extension TPStreamPlayerViewController: FullScreenToggleDelegate, PlayerControls
             window.addSubview(containerView)
             containerView.frame = window.bounds
             isFullScreen = true
+            DispatchQueue.main.async { [weak self] in
+                self?.layoutContainerSubviews()
+            }
         }
     }
     
@@ -310,6 +321,9 @@ extension TPStreamPlayerViewController: FullScreenToggleDelegate, PlayerControls
         view.addSubview(containerView)
         containerView.frame = view.bounds
         isFullScreen = false
+        DispatchQueue.main.async { [weak self] in
+            self?.layoutContainerSubviews()
+        }
     }
     
     func changeOrientation(orientation: UIInterfaceOrientationMask) {

--- a/Source/Utils/VideoRectCalculator.swift
+++ b/Source/Utils/VideoRectCalculator.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+
+enum VideoRectCalculator {
+
+    static func calculate(
+        videoSize: CGSize,
+        containerSize: CGSize
+    ) -> CGRect {
+        guard
+            videoSize.width > 0,
+            videoSize.height > 0,
+            containerSize.width > 0,
+            containerSize.height > 0
+        else {
+            return .zero
+        }
+
+        let videoAspect = videoSize.width / videoSize.height
+        let containerAspect = containerSize.width / containerSize.height
+
+        let renderedSize: CGSize
+
+        if videoAspect > containerAspect {
+            renderedSize = CGSize(
+                width: containerSize.width,
+                height: containerSize.width / videoAspect
+            )
+        } else {
+            renderedSize = CGSize(
+                width: containerSize.height * videoAspect,
+                height: containerSize.height
+            )
+        }
+
+        return CGRect(
+            x: (containerSize.width - renderedSize.width) / 2,
+            y: (containerSize.height - renderedSize.height) / 2,
+            width: renderedSize.width,
+            height: renderedSize.height
+        )
+    }
+}

--- a/Source/Views/UIKit/VideoPlayerView.swift
+++ b/Source/Views/UIKit/VideoPlayerView.swift
@@ -11,10 +11,19 @@ import AVFoundation
 
 class TPVideoPlayerUIView: UIView {
     override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var onVideoRectChanged: ((CGRect) -> Void)?
     
     var player: AVPlayer? {
         get { playerLayer.player }
         set { playerLayer.player = newValue }
     }
+    var videoRect: CGRect { playerLayer.videoRect }
     private var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
+
+    override func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
+        guard layer === self.layer else { return }
+        onVideoRectChanged?(playerLayer.videoRect)
+    }
 }

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -9,6 +9,7 @@ class WatermarkOverlayView: UIView {
     private var watermarks: [WatermarkConfig] = []
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
+    private var videoRect: CGRect?
     private var labelsAreFrozen = false
     private var animationStartTimeByLabelID: [ObjectIdentifier: CFTimeInterval] = [:]
     private var horizontalSpanByLabelID: [ObjectIdentifier: CGFloat] = [:]
@@ -46,6 +47,16 @@ class WatermarkOverlayView: UIView {
         setNeedsLayout()
     }
 
+    /// Sets the rect within this view where the actual video content is rendered.
+    /// Watermarks are positioned relative to this rect instead of the full view bounds,
+    /// preventing them from overlapping letterbox/pillarbox bars.
+    func setVideoRect(_ rect: CGRect) {
+        let effective = rect.isNull || rect.isEmpty ? nil : rect
+        guard effective != videoRect else { return }
+        videoRect = effective
+        setNeedsLayout()
+    }
+
     func pauseWatermarks() {
         guard !labelsAreFrozen else { return }
         labelsAreFrozen = true
@@ -66,8 +77,13 @@ class WatermarkOverlayView: UIView {
         super.layoutSubviews()
         let now = CACurrentMediaTime()
         for (label, config) in zip(labels, watermarks) {
+            guard let videoRect else {
+                label.isHidden = true
+                continue
+            }
+            label.isHidden = false
             label.layer.transform = CATransform3DIdentity
-            label.frame = positionedFrame(for: label, at: config)
+            label.frame = positionedFrame(for: label, at: config, in: videoRect)
             if let animation = config.animation {
                 applyAnimation(animation, to: label, now: now)
             } else {
@@ -79,7 +95,8 @@ class WatermarkOverlayView: UIView {
     }
 
     private func applyAnimation(_ animation: WatermarkAnimation, to label: UILabel, now: CFTimeInterval) {
-        let horizontalSpan = max(bounds.width - label.frame.width - 2 * inset, 0)
+        guard let area = videoRect else { return }
+        let horizontalSpan = max(area.width - label.frame.width - 2 * inset, 0)
         let labelID = ObjectIdentifier(label)
         let storedStartTime = animationStartTimeByLabelID[labelID]
         let storedHorizontalSpan = horizontalSpanByLabelID[labelID]
@@ -131,20 +148,19 @@ class WatermarkOverlayView: UIView {
         return label
     }
 
-    private func positionedFrame(for label: UILabel, at config: WatermarkConfig) -> CGRect {
-        let maxWidth = max(bounds.width - 2 * inset, 0)
+    private func positionedFrame(for label: UILabel, at config: WatermarkConfig, in area: CGRect) -> CGRect {
+        let maxWidth = max(area.width - 2 * inset, 0)
         let size = label.sizeThatFits(CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
-        let horizontalSpan = max(bounds.width - size.width - 2 * inset, 0)
+        let horizontalSpan = max(area.width - size.width - 2 * inset, 0)
         let isPingPongAnimation = config.animation?.type == .pingPong
-        let x = isPingPongAnimation ? inset : inset + horizontalSpan * CGFloat(config.x) / 100
+        let x = area.origin.x + (isPingPongAnimation ? inset : inset + horizontalSpan * CGFloat(config.x) / 100)
 
-        let top = inset
+        let top = area.origin.y + inset
         let bottomLimit: CGFloat
         if reservedBottomHeight > 0 {
-            // Stay just above the reserved band instead of applying the full inset.
-            bottomLimit = max(bounds.height - size.height - reservedBottomHeight - reservedBandGap, top)
+            bottomLimit = max(area.origin.y + area.height - size.height - reservedBottomHeight - reservedBandGap, top)
         } else {
-            bottomLimit = bounds.height - size.height - inset
+            bottomLimit = area.origin.y + area.height - size.height - inset
         }
         let y = top + (bottomLimit - top) * CGFloat(config.y) / 100
         return CGRect(origin: CGPoint(x: x, y: y), size: size)
@@ -197,11 +213,13 @@ struct WatermarkOverlayViewRepresentable: UIViewRepresentable {
     let watermarks: [WatermarkConfig]
     let reservedBottomHeight: CGFloat
     let labelsAreFrozen: Bool
+    let videoRect: CGRect
 
     func makeUIView(context: Context) -> WatermarkOverlayView {
         let view = WatermarkOverlayView(frame: .zero)
         view.setWatermarks(watermarks)
         view.setReservedBottomHeight(reservedBottomHeight)
+        view.setVideoRect(videoRect)
         if labelsAreFrozen {
             view.pauseWatermarks()
         }
@@ -211,6 +229,7 @@ struct WatermarkOverlayViewRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: WatermarkOverlayView, context: Context) {
         uiView.setWatermarks(watermarks)
         uiView.setReservedBottomHeight(reservedBottomHeight)
+        uiView.setVideoRect(videoRect)
         if labelsAreFrozen {
             uiView.pauseWatermarks()
         } else {

--- a/Source/Views/UIKit/WatermarkOverlayView.swift
+++ b/Source/Views/UIKit/WatermarkOverlayView.swift
@@ -9,7 +9,7 @@ class WatermarkOverlayView: UIView {
     private var watermarks: [WatermarkConfig] = []
     private var labels: [UILabel] = []
     private var reservedBottomHeight: CGFloat = 0
-    private var videoRect: CGRect?
+    private var watermarkContentRect: CGRect?
     private var labelsAreFrozen = false
     private var animationStartTimeByLabelID: [ObjectIdentifier: CFTimeInterval] = [:]
     private var horizontalSpanByLabelID: [ObjectIdentifier: CGFloat] = [:]
@@ -50,10 +50,10 @@ class WatermarkOverlayView: UIView {
     /// Sets the rect within this view where the actual video content is rendered.
     /// Watermarks are positioned relative to this rect instead of the full view bounds,
     /// preventing them from overlapping letterbox/pillarbox bars.
-    func setVideoRect(_ rect: CGRect) {
+    func setWatermarkContentRect(_ rect: CGRect) {
         let effective = rect.isNull || rect.isEmpty ? nil : rect
-        guard effective != videoRect else { return }
-        videoRect = effective
+        guard effective != watermarkContentRect else { return }
+        watermarkContentRect = effective
         setNeedsLayout()
     }
 
@@ -77,13 +77,13 @@ class WatermarkOverlayView: UIView {
         super.layoutSubviews()
         let now = CACurrentMediaTime()
         for (label, config) in zip(labels, watermarks) {
-            guard let videoRect else {
+            guard let watermarkContentRect else {
                 label.isHidden = true
                 continue
             }
             label.isHidden = false
             label.layer.transform = CATransform3DIdentity
-            label.frame = positionedFrame(for: label, at: config, in: videoRect)
+            label.frame = positionedFrame(for: label, at: config, in: watermarkContentRect)
             if let animation = config.animation {
                 applyAnimation(animation, to: label, now: now)
             } else {
@@ -95,7 +95,7 @@ class WatermarkOverlayView: UIView {
     }
 
     private func applyAnimation(_ animation: WatermarkAnimation, to label: UILabel, now: CFTimeInterval) {
-        guard let area = videoRect else { return }
+        guard let area = watermarkContentRect else { return }
         let horizontalSpan = max(area.width - label.frame.width - 2 * inset, 0)
         let labelID = ObjectIdentifier(label)
         let storedStartTime = animationStartTimeByLabelID[labelID]
@@ -213,13 +213,13 @@ struct WatermarkOverlayViewRepresentable: UIViewRepresentable {
     let watermarks: [WatermarkConfig]
     let reservedBottomHeight: CGFloat
     let labelsAreFrozen: Bool
-    let videoRect: CGRect
+    let watermarkContentRect: CGRect
 
     func makeUIView(context: Context) -> WatermarkOverlayView {
         let view = WatermarkOverlayView(frame: .zero)
         view.setWatermarks(watermarks)
         view.setReservedBottomHeight(reservedBottomHeight)
-        view.setVideoRect(videoRect)
+        view.setWatermarkContentRect(watermarkContentRect)
         if labelsAreFrozen {
             view.pauseWatermarks()
         }
@@ -229,7 +229,7 @@ struct WatermarkOverlayViewRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: WatermarkOverlayView, context: Context) {
         uiView.setWatermarks(watermarks)
         uiView.setReservedBottomHeight(reservedBottomHeight)
-        uiView.setVideoRect(videoRect)
+        uiView.setWatermarkContentRect(watermarkContentRect)
         if labelsAreFrozen {
             uiView.pauseWatermarks()
         } else {

--- a/iOSPlayerSDK.xcodeproj/project.pbxproj
+++ b/iOSPlayerSDK.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		0394CA312B5E5529006BED3B /* Reachability in Frameworks */ = {isa = PBXBuildFile; productRef = 0394CA302B5E5529006BED3B /* Reachability */; };
 		0397C4872C1C630600D701AA /* TPStreamPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397C4862C1C630600D701AA /* TPStreamPlayerViewModel.swift */; };
 		03B8090A2A2DF8A000AB3D03 /* TPStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B809092A2DF8A000AB3D03 /* TPStreamPlayer.swift */; };
-		2A9F8C1E5B6D7F0A3C4E5D6B /* TpstreamsAssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4E7A9B2D5F8C0A3B6E9D2F /* TpstreamsAssetData.swift */; };
 		03B8090C2A2DF9A200AB3D03 /* PlayerControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8090B2A2DF9A200AB3D03 /* PlayerControlsView.swift */; };
 		03B8090E2A2DFC0F00AB3D03 /* TPStreamsSDKAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03B8090D2A2DFC0F00AB3D03 /* TPStreamsSDKAssets.xcassets */; };
 		03B8FD902A690CAA00DAB7AE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8FD8F2A690CAA00DAB7AE /* AppDelegate.swift */; };
@@ -51,16 +50,18 @@
 		03CE75022A7A337B00B84304 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CE75012A7A337B00B84304 /* UIView.swift */; };
 		03D7F4252C21C64D00DF3597 /* LiveIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */; };
 		03D7F4282C22C4F900DF3597 /* PlaybackSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7F4272C22C4F900DF3597 /* PlaybackSpeed.swift */; };
+		2A9F8C1E5B6D7F0A3C4E5D6B /* TpstreamsAssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4E7A9B2D5F8C0A3B6E9D2F /* TpstreamsAssetData.swift */; };
+		2D1D7D1C3036D2BC00E07B9B /* VideoRectCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1D7D1B3036D2BC00E07B9B /* VideoRectCalculator.swift */; };
 		2D2023032FD6DD1A0077600E /* SwiftSubtitles in Frameworks */ = {isa = PBXBuildFile; productRef = 2D2023022FD6DD1A0077600E /* SwiftSubtitles */; };
 		2D2BA5792F5FEB2400D53996 /* KeychainUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2BA5782F5FEB2400D53996 /* KeychainUtil.swift */; };
 		2D3CE81F2F5957EE0011CAB7 /* VideoQualityUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3CE81E2F5957EE0011CAB7 /* VideoQualityUtils.swift */; };
 		2D46EC6A2EE856BB008B559A /* M3U8Kit in Frameworks */ = {isa = PBXBuildFile; productRef = 2D46EC692EE856BB008B559A /* M3U8Kit */; };
 		2D9798C02FC966D800593EAC /* SubtitleTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9798BF2FC966D800593EAC /* SubtitleTrack.swift */; };
 		2DA51C0A2F60000100AB0C1A /* WatermarkConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA51C0A2F60000100AB0C1B /* WatermarkConfig.swift */; };
+		2DA51C0B2F60000200AB0C1A /* WatermarkOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA51C0B2F60000200AB0C1B /* WatermarkOverlayView.swift */; };
 		2DC08F892F448BB900AABC60 /* EncryptionKeyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC08F872F448BB900AABC60 /* EncryptionKeyDelegate.swift */; };
 		2DD12A212D4CF75400272433 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = D92E48F22CB0226A00B1FAC3 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		2DF3CE142FED6494001872ED /* SubtitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF3CE132FED6494001872ED /* SubtitleTextView.swift */; };
-		2DA51C0B2F60000200AB0C1A /* WatermarkOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA51C0B2F60000200AB0C1B /* WatermarkOverlayView.swift */; };
 		4F02A7FA872249B68023A541 /* SubtitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F02A7FA872249B68023A540 /* SubtitleView.swift */; };
 		70D42E0B2E6075F3002AC32C /* AnyRealmValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */; };
 		8E6389BC2A2724D000306FA4 /* TPStreamPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */; };
@@ -187,7 +188,6 @@
 		03913C472A850BF9002E7E0C /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		0397C4862C1C630600D701AA /* TPStreamPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerViewModel.swift; sourceTree = "<group>"; };
 		03B809092A2DF8A000AB3D03 /* TPStreamPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayer.swift; sourceTree = "<group>"; };
-		1C4E7A9B2D5F8C0A3B6E9D2F /* TpstreamsAssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TpstreamsAssetData.swift; sourceTree = "<group>"; };
 		03B8090B2A2DF9A200AB3D03 /* PlayerControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsView.swift; sourceTree = "<group>"; };
 		03B8090D2A2DFC0F00AB3D03 /* TPStreamsSDKAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = TPStreamsSDKAssets.xcassets; sourceTree = "<group>"; };
 		03B8FD8D2A690CAA00DAB7AE /* StoryboardExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StoryboardExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -211,13 +211,15 @@
 		03CE75012A7A337B00B84304 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		03D7F4242C21C64D00DF3597 /* LiveIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveIndicatorView.swift; sourceTree = "<group>"; };
 		03D7F4272C22C4F900DF3597 /* PlaybackSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackSpeed.swift; sourceTree = "<group>"; };
+		1C4E7A9B2D5F8C0A3B6E9D2F /* TpstreamsAssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TpstreamsAssetData.swift; sourceTree = "<group>"; };
+		2D1D7D1B3036D2BC00E07B9B /* VideoRectCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRectCalculator.swift; sourceTree = "<group>"; };
 		2D2BA5782F5FEB2400D53996 /* KeychainUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainUtil.swift; sourceTree = "<group>"; };
 		2D3CE81E2F5957EE0011CAB7 /* VideoQualityUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoQualityUtils.swift; sourceTree = "<group>"; };
 		2D9798BF2FC966D800593EAC /* SubtitleTrack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleTrack.swift; sourceTree = "<group>"; };
 		2DA51C0A2F60000100AB0C1B /* WatermarkConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkConfig.swift; sourceTree = "<group>"; };
+		2DA51C0B2F60000200AB0C1B /* WatermarkOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkOverlayView.swift; sourceTree = "<group>"; };
 		2DC08F872F448BB900AABC60 /* EncryptionKeyDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyDelegate.swift; sourceTree = "<group>"; };
 		2DF3CE132FED6494001872ED /* SubtitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleTextView.swift; sourceTree = "<group>"; };
-		2DA51C0B2F60000200AB0C1B /* WatermarkOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkOverlayView.swift; sourceTree = "<group>"; };
 		3F02A7FA872249B68023A540 /* SubtitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleView.swift; sourceTree = "<group>"; };
 		70D42E0A2E6075F3002AC32C /* AnyRealmValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		8E6389BB2A2724D000306FA4 /* TPStreamPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStreamPlayerView.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 				03CE74FF2A7946A800B84304 /* Time.swift */,
 				2D3CE81E2F5957EE0011CAB7 /* VideoQualityUtils.swift */,
 				0367F6F42B861CFC0000922D /* Sentry.swift */,
+				2D1D7D1B3036D2BC00E07B9B /* VideoRectCalculator.swift */,
 				2D2BA5782F5FEB2400D53996 /* KeychainUtil.swift */,
 				D960A8FA2CEDEE7C003B0B04 /* M3U8Parser.swift */,
 			);
@@ -818,6 +821,7 @@
 				0367F6F52B861CFC0000922D /* Sentry.swift in Sources */,
 				0377C4132A2B272C00F7E58F /* TestpressAPI.swift in Sources */,
 				0377C4112A2B1F0700F7E58F /* Asset.swift in Sources */,
+				2D1D7D1C3036D2BC00E07B9B /* VideoRectCalculator.swift in Sources */,
 				8E6389E22A275AA800306FA4 /* StreamsAPI.swift in Sources */,
 				03BF8C522B173ED10006CBC1 /* TPStreamPlayerConfiguration.swift in Sources */,
 				0397C4872C1C630600D701AA /* TPStreamPlayerViewModel.swift in Sources */,


### PR DESCRIPTION
Watermarks were positioned relative to the full player view bounds, causing them to appear on letterbox/pillarbox black bars when the video's aspect ratio differs from the player view (e.g. in fullscreen).

Now uses AVPlayerLayer.videoRect to calculate watermark positions relative to the actual rendered video content area, ensuring watermarks stay within the video boundaries regardless of aspect ratio mismatch.

Changes:
- Expose videoRect from TPVideoPlayerUIView via AVPlayerLayer.videoRect
- WatermarkOverlayView positions labels relative to videoRect instead of bounds
- Wire videoRect through UIKit (TPStreamPlayerViewController) and SwiftUI paths