### PR TITLE
fix: Enable live video playback while transcoding in progress

### DIFF
--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -18,6 +18,13 @@ struct Asset {
     
     var playbackURL: String? {
         if let video = video {
+            if let liveStream = liveStream, video.status.lowercased() == "completed" && liveStream.transcodeRecordedVideo == false, liveStream.isStreaming {
+                return liveStream.hlsUrl
+            }
+            if video.status.lowercased() != "completed",
+               let liveStream = liveStream {
+                return liveStream.hlsUrl
+            }
             return video.playbackURL
         } else if let liveStream = liveStream {
             return liveStream.hlsUrl

--- a/Source/Network/Models/Asset.swift
+++ b/Source/Network/Models/Asset.swift
@@ -18,9 +18,7 @@ struct Asset {
     
     var playbackURL: String? {
         if let video = video {
-            if let liveStream = liveStream, video.status.lowercased() == "completed" && liveStream.transcodeRecordedVideo == false, liveStream.isStreaming {
-                return liveStream.hlsUrl
-            }
+            // Backend keeps live hls_url playable after the stream ends; we use it until transcoding completes.
             if video.status.lowercased() != "completed",
                let liveStream = liveStream {
                 return liveStream.hlsUrl


### PR DESCRIPTION
- After a live stream ended, the player kept using the transcoded playback URL while that video was still processing, so playback failed until transcoding finished.
- It now falls back to the live HLS URL until transcoding completes, so users can keep watching without waiting.
